### PR TITLE
Dev

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,6 +19,6 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 
-    <Version>1.3.1</Version>
+    <Version>1.3.2</Version>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -63,6 +63,28 @@ A result can be either in an Ok or Failed state.
 
 >**Note**: When using nullable contexts, the compiler will not generate "may be null" warnings in these cases, as the library leverages conditional attributes to assist null-state analysis.
 
+Checking the state of a result to run some business logic is straightforward:
+
+``` csharp
+public async Task<Result<PerformGetBookByIdResponse>> PerformGetBookById(GetBookByIdRequest req, CancellationToken ct)
+{
+    var result = await GetBookById(req, ct);
+
+    if (result.IsFailed)
+    {
+        // Handle failure case,
+        Console.WriteLine($"GetBookById has failed.");
+        // Return the failure information as a failed Result<PerformGetBookByIdResponse>
+        // FailureResult can be implicitly converted to Result<TAnyValue>, so we can return it directly.
+        return FailureResult.From(result);
+    }
+    // Handle success case, access value via result.Value
+    // ...
+}
+```
+
+Sometimes, you may want to convert a `Result<TValue>` to a `Result` (which doesn't hold a value object, just state and information related to it) while preserving the failure information. You can do this using the implicit operator or the `AsResult()`/`ToResult()` methods:
+
 ``` csharp
 public async Task<Result> PerformGetBookById(GetBookByIdRequest req, CancellationToken ct)
 {
@@ -75,7 +97,30 @@ public async Task<Result> PerformGetBookById(GetBookByIdRequest req, Cancellatio
     {
         Console.WriteLine($"GetBookById has failed.");
     }
+    // Implicitly convert Result<GetBookByIdResponse> to Result, preserving state and any failure information.
     return result
+}
+```
+
+Other times, you may want to convert a `Result<TSourceValue>` to a `Result<TTargetValue>` while preserving the failure information. You can do this using the `AsResult<TTargetValue>()`/`ToResult<TTargetValue>()` methods or any similar overloads with same name:
+
+``` csharp
+public async Task<Result<PerformGetBookByIdResponse>> PerformGetBookById(GetBookByIdRequest req, CancellationToken ct)
+{
+    var result = await GetBookById(req, ct);
+
+    // Convert Result<GetBookByIdResponse> to Result<PerformGetBookByIdResponse>, 
+    // preserving state and any failure information.
+    // Factory parameter will be called only if the source result is in Ok state,
+    // and it will receive the value of type GetBookByIdResponse (TSourceValue)
+    // to create a value of type PerformGetBookByIdResponse (TTargetValue).
+    return result.AsResult<PerformGetBookByIdResponse>(v => 
+    {
+        // Construct a PerformGetBookByIdResponse using the value of type GetBookByIdResponse (v) and return it. 
+        // This factory will only be called if the result is in Ok state, 
+        // otherwise the failure information will be preserved and returned as a failed Result<PerformGetBookByIdResponse>.
+        return new PerformGetBookById(v.Name);
+    });
 }
 ```
 

--- a/docs/ConvertingResults.md
+++ b/docs/ConvertingResults.md
@@ -1,14 +1,16 @@
 ## Convert Result&lt;TValue&gt; to Result
 
-Converting a Result&lt;TValue&gt; object to Result is straightforward, and can be achieved by calling parameterless ToResult() method of Result&lt;TValue&gt; instance or can be left to implicit operator.
+Converting a Result&lt;TValue&gt; object to Result is straightforward, and can be achieved by calling parameterless AsResult() or ToResult() method of Result&lt;TValue&gt; instance or can be left to implicit operator.
 
-Any Failure information, Errors, Facts and Warnings are automatically copied to output Result.
+Implicit operator and AsResult() method wraps Failure and Statement objects of the source result.
+
+ToResult() method copies over any Failure information, Errors, Facts and Warnings to output Result.
 
 ## Convert a Result instance to Result&lt;TValue&gt; or a Result&lt;TSourceValue&gt; instance to Result&lt;TValue&gt;
 
 These types of conversions require a TValue object creation for Ok state of output Result&lt;TValue&gt; object.
 
-There are various overloads of [ToResult() and ToResultAsync()](../src/ModResults/ResultConversionExtensions.cs) extension methods that accepts TValue object factory functions and additional parameters for such conversions. Any Failure information, Errors, Facts and Warnings are automatically copied to output Result.
+There are various overloads of [AsResult() and AsResultAsync()](../src/ModResults/ResultConversionExtensions_As.cs) extension methods that accepts TValue object factory functions and additional parameters for such conversions. Output result wraps Failure and Statement objects of the source result.
 
 ``` csharp
 public record Request(string Name);
@@ -18,7 +20,7 @@ public record Response(string Reply);
 public Result<Response> GetResponse(Request req, CancellationToken ct)
 {
     Result<string> result = await GetMeAResultOfString(req.Name, ct);
-    return result.ToResult(x => new Response(x));
+    return result.AsResult(x => new Response(x));
 }
 
 private async Task<Result<string>> GetMeAResultOfString(string name, CancellationToken ct)
@@ -28,4 +30,15 @@ private async Task<Result<string>> GetMeAResultOfString(string name, Cancellatio
 
     return $"Hello {name}";
 }
+```
+
+Similarly, there are various overloads of [ToResult() and ToResultAsync()](../src/ModResults/ResultConversionExtensions.cs) extension methods that accepts TValue object factory functions and additional parameters for such conversions. Any Failure information, Errors, Facts and Warnings are automatically copied to output Result.
+
+``` csharp
+public Result<Response> GetResponse(Request req, CancellationToken ct)
+{
+    Result<string> result = await GetMeAResultOfString(req.Name, ct);
+    return result.ToResult(x => new Response(x));
+}
+
 ```

--- a/docs/ImplicitOperators.md
+++ b/docs/ImplicitOperators.md
@@ -29,11 +29,11 @@ The `FailureResult` class serves as a helper for returning failed `Result<TValue
 
 - `Result.Ok(TValue value)` static method for creating a successful `Result<TValue>` instead of calling `Result<TValue>.Ok(TValue value)`,
 - Static factory methods for creating failed results with specific failure types, such as `Result.NotFound()`, `Result<TValue>.Invalid()`, etc.
-- Static `Fail` method to create a failed `Result` or `Result<TValue>` from another `Result` or `Result<TValue>` instance, copying all Failure information, Errors, Facts, and Warnings.
+- Static `Fail` method to create a failed `Result` or `Result<TValue>` from another `Result` or `Result<TValue>` instance, either wrapping Statement and Failure objects of source result or copying all Failure information, Errors, Facts, and Warnings.
 - `Result<TValue>` to `Result` using `ToResult()` method (in same state, copies contents of Failure and Statement objects of source),
 - `Result<TValue>` as `Result` using `AsResult()` method (in same state, uses same Failure and Statement objects of source),
 - `FailureResult` to `Result<TValue>` and `Result` using `ToResult<TValue>()` and `ToResult()` methods (in same state, copies contents of Failure and Statement objects of source),
 - `FailureResult` as `Result<TValue>` and `Result` using `AsResult<TValue>()` and `AsResult()` methods (in same state, uses same Failure and Statement objects of source),
 - `Result` to `Result<TValue>` using `ToResult()` method with a factory function for `TValue`,
-- Extension methods like `ToResultAsync()` or `MapAsync()` for asynchronous conversions,
+- Extension methods like `AsResultAsync()`, `ToResultAsync()` or `MapAsync()` for asynchronous conversions,
 - Extension methods to check items in Error, Fact, Warning collections and to add new items to Fact and Warning collections.

--- a/docs/ImplicitOperators.md
+++ b/docs/ImplicitOperators.md
@@ -3,6 +3,7 @@
 `Result` and `Result<TValue>` classes provide implicit operators and quality of life (QoL) features to simplify the creation and handling of results in your code. These features allow you to easily convert between different types and create results without needing to explicitly call factory methods.
 
 The `FailureResult` class serves as a helper for returning failed `Result<TValue>` instances without needing to specify `TValue` directly, using implicit conversion operators. It is also designed for easy conversion to both `Result` and `Result<TValue>` types, enabling seamless integration of failure information into your result handling.
+
 ``` csharp
     public Result<TValue> AwesomeMethod<TValue>()
     {

--- a/src/ModResults.Orleans/FailureResultSurrogateConverter.cs
+++ b/src/ModResults.Orleans/FailureResultSurrogateConverter.cs
@@ -16,7 +16,7 @@ public sealed class FailureResultSurrogateConverter :
     return new FailureResultSurrogate()
     {
       Failure = value.Failure,
-      Statements = value.PeekStatements()
+      Statements = value.HasStatements() ? value.Statements : null
     };
   }
 }

--- a/src/ModResults.Orleans/FailureResultSurrogateConverter.cs
+++ b/src/ModResults.Orleans/FailureResultSurrogateConverter.cs
@@ -16,7 +16,7 @@ public sealed class FailureResultSurrogateConverter :
     return new FailureResultSurrogate()
     {
       Failure = value.Failure,
-      Statements = value.HasStatements() ? value.Statements : null
+      Statements = value.PeekStatements()
     };
   }
 }

--- a/src/ModResults.Orleans/ResultSurrogateConverter.cs
+++ b/src/ModResults.Orleans/ResultSurrogateConverter.cs
@@ -18,7 +18,7 @@ public sealed class ResultSurrogateConverter :
     {
       IsOk = value.IsOk,
       Failure = value.Failure,
-      Statements = value.PeekStatements()
+      Statements = value.HasStatements() ? value.Statements : null
     };
   }
 }
@@ -45,7 +45,7 @@ public sealed class ResultSurrogateConverter<TValue> :
       IsOk = value.IsOk,
       Failure = value.Failure,
       Value = value.Value,
-      Statements = value.PeekStatements()
+      Statements = value.HasStatements() ? value.Statements : null
     };
   }
 }

--- a/src/ModResults.Orleans/ResultSurrogateConverter.cs
+++ b/src/ModResults.Orleans/ResultSurrogateConverter.cs
@@ -18,7 +18,7 @@ public sealed class ResultSurrogateConverter :
     {
       IsOk = value.IsOk,
       Failure = value.Failure,
-      Statements = value.HasStatements() ? value.Statements : null
+      Statements = value.PeekStatements()
     };
   }
 }
@@ -45,7 +45,7 @@ public sealed class ResultSurrogateConverter<TValue> :
       IsOk = value.IsOk,
       Failure = value.Failure,
       Value = value.Value,
-      Statements = value.HasStatements() ? value.Statements : null
+      Statements = value.PeekStatements()
     };
   }
 }

--- a/src/ModResults/BaseResultFailureExtensions.cs
+++ b/src/ModResults/BaseResultFailureExtensions.cs
@@ -50,8 +50,7 @@ public static class BaseResultFailureExtensions
       string code,
       StringComparison comparisonType = Definitions.DefaultComparisonType)
     {
-      return (result.Failure?.HasErrors() ?? false) &&
-        result.Failure.Errors.Any(e => e.HasCode(code, comparisonType));
+      return result.Failure?.PeekErrors()?.Any(e => e.HasCode(code, comparisonType)) ?? false;
     }
 
     /// <summary>
@@ -87,11 +86,7 @@ public static class BaseResultFailureExtensions
       string code,
       StringComparison comparisonType)
     {
-      if ((result.Failure?.HasErrors() ?? false))
-      {
-        return result.Failure.Errors.Where(e => e.HasCode(code, comparisonType));
-      }
-      return [];
+      return result.Failure?.PeekErrors()?.Where(e => e.HasCode(code, comparisonType)) ?? [];
     }
 
     /// <summary>
@@ -104,8 +99,7 @@ public static class BaseResultFailureExtensions
       bool includeAssignableTo = false)
       where TException : Exception
     {
-      return (result.Failure?.HasErrors() ?? false) &&
-        result.Failure.Errors.Any(e => e.HasException<TException>(includeAssignableTo));
+      return result.Failure?.PeekErrors()?.Any(e => e.HasException<TException>(includeAssignableTo)) ?? false;
     }
 
     /// <summary>
@@ -140,11 +134,7 @@ public static class BaseResultFailureExtensions
     private IEnumerable<Error> GetErrorsWithExceptionInternal<TException>(
       bool includeAssignableTo = false) where TException : Exception
     {
-      if ((result.Failure?.HasErrors() ?? false))
-      {
-        return result.Failure.Errors.Where(e => e.HasException<TException>(includeAssignableTo));
-      }
-      return [];
+      return result.Failure?.PeekErrors()?.Where(e => e.HasException<TException>(includeAssignableTo)) ?? [];
     }
 
     /// <summary>
@@ -157,8 +147,7 @@ public static class BaseResultFailureExtensions
       Type exceptionType,
       bool includeAssignableTo = false)
     {
-      return (result.Failure?.HasErrors() ?? false) &&
-        result.Failure.Errors.Any(e => e.HasException(exceptionType, includeAssignableTo));
+      return result.Failure?.PeekErrors()?.Any(e => e.HasException(exceptionType, includeAssignableTo)) ?? false;
     }
 
     /// <summary>
@@ -194,11 +183,7 @@ public static class BaseResultFailureExtensions
       Type exceptionType,
       bool includeAssignableTo = false)
     {
-      if ((result.Failure?.HasErrors() ?? false))
-      {
-        return result.Failure.Errors.Where(e => e.HasException(exceptionType, includeAssignableTo));
-      }
-      return [];
+      return result.Failure?.PeekErrors()?.Where(e => e.HasException(exceptionType, includeAssignableTo)) ?? [];
     }
   }
 }

--- a/src/ModResults/BaseResultFailureExtensions.cs
+++ b/src/ModResults/BaseResultFailureExtensions.cs
@@ -8,6 +8,22 @@ public static class BaseResultFailureExtensions
   extension(BaseResult<Failure> result)
   {
     /// <summary>
+    /// Converts to a <see cref="FailureResult"/>, copying over Failure and Statements information.
+    /// If source result has no Failure (in Ok state), the returned FailureResult will have a Failure with type set to Unspecified and no errors.
+    /// </summary>
+    /// <returns></returns>
+    public FailureResult ToFailureResult() => FailureResult.FromResult(result);
+
+    /// <summary>
+    /// Returns a <see cref="FailureResult"/> that wraps the same state, Failure and Statements as the source result.
+    /// If source result has no Failure (in Ok state), the returned FailureResult will have a Failure with type set to Unspecified and no errors.
+    /// </summary>
+    /// <returns></returns>
+    public FailureResult AsFailureResult() => new(
+      result.Failure is null ? Failure.Create(FailureType.Unspecified) : result.Failure,
+      result.HasStatements() ? result.Statements : null);
+
+    /// <summary>
     /// Dumps the state, failure type, errors, facts and warnings of the result as a formatted string.
     /// </summary>
     /// <returns></returns>

--- a/src/ModResults/BaseResultFailureExtensions.cs
+++ b/src/ModResults/BaseResultFailureExtensions.cs
@@ -8,22 +8,6 @@ public static class BaseResultFailureExtensions
   extension(BaseResult<Failure> result)
   {
     /// <summary>
-    /// Converts to a <see cref="FailureResult"/>, copying over Failure and Statements information.
-    /// If source result has no Failure (in Ok state), the returned FailureResult will have a Failure with type set to Unspecified and no errors.
-    /// </summary>
-    /// <returns></returns>
-    public FailureResult ToFailureResult() => FailureResult.FromResult(result);
-
-    /// <summary>
-    /// Returns a <see cref="FailureResult"/> that wraps the same state, Failure and Statements as the source result.
-    /// If source result has no Failure (in Ok state), the returned FailureResult will have a Failure with type set to Unspecified and no errors.
-    /// </summary>
-    /// <returns></returns>
-    public FailureResult AsFailureResult() => new(
-      result.Failure is null ? Failure.Create(FailureType.Unspecified) : result.Failure,
-      result.HasStatements() ? result.Statements : null);
-
-    /// <summary>
     /// Dumps the state, failure type, errors, facts and warnings of the result as a formatted string.
     /// </summary>
     /// <returns></returns>

--- a/src/ModResults/Failure.cs
+++ b/src/ModResults/Failure.cs
@@ -28,6 +28,15 @@ public sealed class Failure
   }
 
   /// <summary>
+  /// Gets the current collection of errors if it has been initialized.
+  /// </summary>
+  /// <returns>The current <see cref="Error"/> list instance if it has been initialized; otherwise, <see langword="null"/>.</returns>
+  internal List<Error>? PeekErrors()
+  {
+    return _errors;
+  }
+
+  /// <summary>
   /// Type of failure.
   /// </summary>
   public FailureType Type { get; }

--- a/src/ModResults/Failure.cs
+++ b/src/ModResults/Failure.cs
@@ -55,4 +55,9 @@ public sealed class Failure
   {
     return new Failure(type, errors);
   }
+
+  internal static Failure Create(FailureType type)
+  {
+    return new Failure(type, null);
+  }
 }

--- a/src/ModResults/FailureResult.cs
+++ b/src/ModResults/FailureResult.cs
@@ -62,24 +62,35 @@ public sealed class FailureResult : BaseBusinessResult<FailureResult>
   }
 
   /// <summary>
-  /// Creates a <see cref="FailureResult"/> from another result instance whose failure property is of type <see cref="ModResults.Failure"/>, copying over Statements and any Failure information.
+  /// Creates a <see cref="FailureResult"/> from another result instance whose failure property is of type <see cref="ModResults.Failure"/>.
+  /// If source result has no Failure (in Ok state), the returned FailureResult will have a Failure with type set to Unspecified and no errors.
   /// </summary>
   /// <param name="result"></param>
+  /// <param name="wrapSourceProperties">If <see langword="true"/>, wraps Failure and Statement objects of the source result; otherwise, copies over Statement and any Failure information from source.</param>
   /// <returns></returns>
-  public static FailureResult FromResult(BaseResult<Failure> result)
+  public static FailureResult From(BaseResult<Failure> result, bool wrapSourceProperties = true)
   {
-    if (result.Failure is null)
+    if (wrapSourceProperties)
     {
-      return new FailureResult(FailureType.Unspecified)
+      return new(
+        result.Failure is null ? Failure.Create(FailureType.Unspecified) : result.Failure,
+        result.HasStatements() ? result.Statements : null);
+    }
+    else
+    {
+      if (result.Failure is null)
+      {
+        return new FailureResult(FailureType.Unspecified)
+          .WithStatementsFrom(result);
+      }
+      if (result.Failure.HasErrors())
+      {
+        return new FailureResult(result.Failure.Type, result.Failure.Errors)
+          .WithStatementsFrom(result);
+      }
+      return new FailureResult(result.Failure.Type)
         .WithStatementsFrom(result);
     }
-    if (result.Failure.HasErrors())
-    {
-      return new FailureResult(result.Failure.Type, result.Failure.Errors)
-        .WithStatementsFrom(result);
-    }
-    return new FailureResult(result.Failure.Type)
-      .WithStatementsFrom(result);
   }
 
   /// <summary>

--- a/src/ModResults/FailureResult.cs
+++ b/src/ModResults/FailureResult.cs
@@ -62,6 +62,27 @@ public sealed class FailureResult : BaseBusinessResult<FailureResult>
   }
 
   /// <summary>
+  /// Creates a <see cref="FailureResult"/> from another result instance whose failure property is of type <see cref="ModResults.Failure"/>, copying over Statements and any Failure information.
+  /// </summary>
+  /// <param name="result"></param>
+  /// <returns></returns>
+  public static FailureResult FromResult(BaseResult<Failure> result)
+  {
+    if (result.Failure is null)
+    {
+      return new FailureResult(FailureType.Unspecified)
+        .WithStatementsFrom(result);
+    }
+    if (result.Failure.HasErrors())
+    {
+      return new FailureResult(result.Failure.Type, result.Failure.Errors)
+        .WithStatementsFrom(result);
+    }
+    return new FailureResult(result.Failure.Type)
+      .WithStatementsFrom(result);
+  }
+
+  /// <summary>
   /// Creates a <see cref="FailureResult"/> with failure type <see cref="FailureType.CriticalError"/> containing an error constructed from specified exception.
   /// </summary>
   /// <param name="exception">The <see cref="Exception"/> that will used to construct an error instance from.</param>

--- a/src/ModResults/FailureResult.cs
+++ b/src/ModResults/FailureResult.cs
@@ -27,7 +27,7 @@ public sealed class FailureResult : BaseBusinessResult<FailureResult>
   private FailureResult(FailureType failureType)
   {
     IsOk = false;
-    Failure = new Failure(failureType, null);
+    Failure = Failure.Create(failureType);
   }
 
   internal static FailureResult Create(FailureType failureType, IEnumerable<Error> errors)

--- a/src/ModResults/FailureResult.cs
+++ b/src/ModResults/FailureResult.cs
@@ -18,6 +18,12 @@ public sealed class FailureResult : BaseBusinessResult<FailureResult>
   [NotNull]
   public override Failure? Failure { get; init; }
 
+  private FailureResult(FailureType failureType, IReadOnlyList<Error>? errors)
+  {
+    IsOk = false;
+    Failure = new Failure(failureType, errors);
+  }
+
   private FailureResult(FailureType failureType, IEnumerable<Error> errors)
   {
     IsOk = false;
@@ -83,12 +89,7 @@ public sealed class FailureResult : BaseBusinessResult<FailureResult>
         return new FailureResult(FailureType.Unspecified)
           .WithStatementsFrom(result);
       }
-      if (result.Failure.HasErrors())
-      {
-        return new FailureResult(result.Failure.Type, result.Failure.Errors)
-          .WithStatementsFrom(result);
-      }
-      return new FailureResult(result.Failure.Type)
+      return new FailureResult(result.Failure.Type, result.Failure.PeekErrors())
         .WithStatementsFrom(result);
     }
   }

--- a/src/ModResults/FailureResult.cs
+++ b/src/ModResults/FailureResult.cs
@@ -74,7 +74,7 @@ public sealed class FailureResult : BaseBusinessResult<FailureResult>
     {
       return new(
         result.Failure is null ? Failure.Create(FailureType.Unspecified) : result.Failure,
-        result.HasStatements() ? result.Statements : null);
+        result.PeekStatements());
     }
     else
     {

--- a/src/ModResults/FailureResultExtensions.cs
+++ b/src/ModResults/FailureResultExtensions.cs
@@ -27,7 +27,7 @@ public static class FailureResultExtensions
     public Result AsResult() => new(
       false,
       result.Failure,
-      result.HasStatements() ? result.Statements : null);
+      result.PeekStatements());
 
     /// <summary>
     /// Returns a <see cref="Result{TValue}"/> that wraps the same state, Failure and Statements as the source <see cref="FailureResult"/>.
@@ -38,7 +38,7 @@ public static class FailureResultExtensions
       false,
       default,
       result.Failure,
-      result.HasStatements() ? result.Statements : null);
+      result.PeekStatements());
     #endregion
 
     #region "Error"

--- a/src/ModResults/FailureResultExtensions.cs
+++ b/src/ModResults/FailureResultExtensions.cs
@@ -24,14 +24,21 @@ public static class FailureResultExtensions
     /// Returns a <see cref="Result"/> that wraps the same state, Failure and Statements as the source <see cref="FailureResult"/>.
     /// </summary>
     /// <returns></returns>
-    public Result AsResult() => new(false, result.Failure, result.Statements);
+    public Result AsResult() => new(
+      false,
+      result.Failure,
+      result.HasStatements() ? result.Statements : null);
 
     /// <summary>
     /// Returns a <see cref="Result{TValue}"/> that wraps the same state, Failure and Statements as the source <see cref="FailureResult"/>.
     /// </summary>
     /// <typeparam name="TValue"></typeparam>
     /// <returns></returns>
-    public Result<TValue> AsResult<TValue>() where TValue : notnull => new(false, default, result.Failure, result.Statements);
+    public Result<TValue> AsResult<TValue>() where TValue : notnull => new(
+      false,
+      default,
+      result.Failure,
+      result.HasStatements() ? result.Statements : null);
     #endregion
 
     #region "Error"

--- a/src/ModResults/FailureResultExtensions.cs
+++ b/src/ModResults/FailureResultExtensions.cs
@@ -9,14 +9,14 @@ public static class FailureResultExtensions
     /// Converts a <see cref="FailureResult"/> to a <see cref="Result"/>, copying over Failure and Statements information.
     /// </summary>
     /// <returns></returns>
-    public Result ToResult() => Result.Fail(result);
+    public Result ToResult() => Result.Fail(result, false);
 
     /// <summary>
     /// Converts a <see cref="FailureResult"/> to a <see cref="Result{TValue}"/>, copying over Failure and Statements information.
     /// </summary>
     /// <typeparam name="TValue"></typeparam>
     /// <returns></returns>
-    public Result<TValue> ToResult<TValue>() where TValue : notnull => Result<TValue>.Fail(result);
+    public Result<TValue> ToResult<TValue>() where TValue : notnull => Result<TValue>.Fail(result, false);
     #endregion
 
     #region "AsResult"

--- a/src/ModResults/Result.cs
+++ b/src/ModResults/Result.cs
@@ -120,12 +120,7 @@ public sealed class Result : BaseBusinessResult<Result>
         return new Result(FailureType.Unspecified)
           .WithStatementsFrom(result);
       }
-      if (result.Failure.HasErrors())
-      {
-        return new Result(result.Failure.Type, result.Failure.Errors)
-          .WithStatementsFrom(result);
-      }
-      return new Result(result.Failure.Type, null)
+      return new Result(result.Failure.Type, result.Failure.PeekErrors())
         .WithStatementsFrom(result);
     }
   }
@@ -264,13 +259,9 @@ public sealed class Result<TValue> : BaseBusinessResult<Result<TValue>, TValue>
         return new Result<TValue>(FailureType.Unspecified)
           .WithStatementsFrom(result);
       }
-      if (result.Failure.HasErrors())
-      {
-        return new Result<TValue>(result.Failure.Type, result.Failure.Errors)
-          .WithStatementsFrom(result);
-      }
-      return new Result<TValue>(result.Failure.Type, null)
+      return new Result<TValue>(result.Failure.Type, result.Failure.PeekErrors())
         .WithStatementsFrom(result);
+
     }
   }
 

--- a/src/ModResults/Result.cs
+++ b/src/ModResults/Result.cs
@@ -26,7 +26,7 @@ public sealed class Result : BaseBusinessResult<Result>
   private Result(FailureType failureType)
   {
     IsOk = false;
-    Failure = new Failure(failureType, null);
+    Failure = Failure.Create(failureType);
   }
 
   internal static Result Create(FailureType failureType, IEnumerable<Error> errors)
@@ -174,7 +174,7 @@ public sealed class Result<TValue> : BaseBusinessResult<Result<TValue>, TValue>
   private Result(FailureType failureType)
   {
     IsOk = false;
-    Failure = new Failure(failureType, null);
+    Failure = Failure.Create(failureType);
   }
 
   internal static Result<TValue> Create(FailureType failureType, IEnumerable<Error> errors)

--- a/src/ModResults/Result.cs
+++ b/src/ModResults/Result.cs
@@ -98,24 +98,36 @@ public sealed class Result : BaseBusinessResult<Result>
   }
 
   /// <summary>
-  /// Creates a failed <see cref="Result"/> from another result instance whose failure property is of type <see cref="ModResults.Failure"/>, copying over Statements and any Failure information.
+  /// Creates a failed <see cref="Result"/> from another result instance whose failure property is of type <see cref="ModResults.Failure"/>.
+  /// If source result has no Failure (in Ok state), the returned FailureResult will have a Failure with type set to Unspecified and no errors.
   /// </summary>
   /// <param name="result"></param>
+  /// <param name="wrapSourceProperties">If <see langword="true"/>, wraps Failure and Statement objects of the source result; otherwise, copies over Statement and any Failure information from source.</param>
   /// <returns></returns>
-  public static Result Fail(BaseResult<Failure> result)
+  public static Result Fail(BaseResult<Failure> result, bool wrapSourceProperties = true)
   {
-    if (result.Failure is null)
+    if (wrapSourceProperties)
     {
-      return new Result(FailureType.Unspecified)
+      return new(
+        false,
+        result.Failure is null ? Failure.Create(FailureType.Unspecified) : result.Failure,
+        result.PeekStatements());
+    }
+    else
+    {
+      if (result.Failure is null)
+      {
+        return new Result(FailureType.Unspecified)
+          .WithStatementsFrom(result);
+      }
+      if (result.Failure.HasErrors())
+      {
+        return new Result(result.Failure.Type, result.Failure.Errors)
+          .WithStatementsFrom(result);
+      }
+      return new Result(result.Failure.Type, null)
         .WithStatementsFrom(result);
     }
-    if (result.Failure.HasErrors())
-    {
-      return new Result(result.Failure.Type, result.Failure.Errors)
-        .WithStatementsFrom(result);
-    }
-    return new Result(result.Failure.Type, null)
-      .WithStatementsFrom(result);
   }
 
   /// <summary>
@@ -229,24 +241,37 @@ public sealed class Result<TValue> : BaseBusinessResult<Result<TValue>, TValue>
   }
 
   /// <summary>
-  /// Creates a failed <see cref="Result{TValue}"/> from another result instance whose failure property is of type <see cref="ModResults.Failure"/>, copying over Statements and any Failure information.
+  /// Creates a failed <see cref="Result{TValue}"/> from another result instance whose failure property is of type <see cref="ModResults.Failure"/>.
+  /// If source result has no Failure (in Ok state), the returned FailureResult will have a Failure with type set to Unspecified and no errors.
   /// </summary>
   /// <param name="result"></param>
+  /// <param name="wrapSourceProperties">If <see langword="true"/>, wraps Failure and Statement objects of the source result; otherwise, copies over Statement and any Failure information from source.</param>
   /// <returns></returns>
-  public static Result<TValue> Fail(BaseResult<Failure> result)
+  public static Result<TValue> Fail(BaseResult<Failure> result, bool wrapSourceProperties = true)
   {
-    if (result.Failure is null)
+    if (wrapSourceProperties)
     {
-      return new Result<TValue>(FailureType.Unspecified)
+      return new(
+        false,
+        default,
+        result.Failure is null ? Failure.Create(FailureType.Unspecified) : result.Failure,
+        result.PeekStatements());
+    }
+    else
+    {
+      if (result.Failure is null)
+      {
+        return new Result<TValue>(FailureType.Unspecified)
+          .WithStatementsFrom(result);
+      }
+      if (result.Failure.HasErrors())
+      {
+        return new Result<TValue>(result.Failure.Type, result.Failure.Errors)
+          .WithStatementsFrom(result);
+      }
+      return new Result<TValue>(result.Failure.Type, null)
         .WithStatementsFrom(result);
     }
-    if (result.Failure.HasErrors())
-    {
-      return new Result<TValue>(result.Failure.Type, result.Failure.Errors)
-        .WithStatementsFrom(result);
-    }
-    return new Result<TValue>(result.Failure.Type, null)
-      .WithStatementsFrom(result);
   }
 
   /// <summary>

--- a/src/ModResults/ResultConversionExtensions_As.cs
+++ b/src/ModResults/ResultConversionExtensions_As.cs
@@ -5,43 +5,42 @@ public static partial class ResultConversionExtensions
   extension(Result result)
   {
     /// <summary>
-    /// Converts a <see cref="Result"/> to a <see cref="Result{TValue}"/>, copying over Statement and any Failure information from source result.
+    /// Converts a <see cref="Result"/> to a <see cref="Result{TValue}"/>, wrapping Failure and Statement objects of the source result.
     /// If source <see cref="Result"/> is in Ok state, the returned <see cref="Result{TValue}"/> will be in Ok state with the provided value.
     /// If source <see cref="Result"/> is in Fail state, the returned <see cref="Result{TValue}"/> will be in Fail state with the same <see cref="Failure"/> information.
     /// </summary>
     /// <typeparam name="TValue"></typeparam>
     /// <param name="valueOnOk">Value to be encapsulated by returning <see cref="Result{TValue}"/> if source result in Ok state.</param>
     /// <returns></returns>
-    public Result<TValue> ToResult<TValue>(
+    public Result<TValue> AsResult<TValue>(
       TValue valueOnOk)
       where TValue : notnull
     {
       return result.Map<Result<TValue>>(
-        okResult => Result<TValue>.Ok(valueOnOk)
-          .WithStatementsFrom(okResult),
-        failResult => Result<TValue>.Fail(failResult, false));
+        okResult => new Result<TValue>(true, valueOnOk, null, okResult.PeekStatements()),
+        failResult => Result<TValue>.Fail(failResult));
     }
 
     /// <summary>
-    /// Converts a <see cref="Result"/> to a <see cref="Result{TValue}"/>, copying over Statement and any Failure information from source result.
+    /// Converts a <see cref="Result"/> to a <see cref="Result{TValue}"/>, wrapping Failure and Statement objects of the source result.
     /// If source <see cref="Result"/> is in Ok state, the returned <see cref="Result{TValue}"/> will be in Ok state with the result of value function as value.
     /// If source <see cref="Result"/> is in Fail state, the returned <see cref="Result{TValue}"/> will be in Fail state with the same <see cref="Failure"/> information.
     /// </summary>
     /// <typeparam name="TValue"></typeparam>
     /// <param name="valueFuncOnOk">The function used to generate value if source result in Ok state.</param>
     /// <returns></returns>
-    public Result<TValue> ToResult<TValue>(
+    public Result<TValue> AsResult<TValue>(
       Func<TValue> valueFuncOnOk)
       where TValue : notnull
     {
-      return result.ToResult(WrapFactoryCallback, valueFuncOnOk);
+      return result.AsResult(WrapFactoryCallback, valueFuncOnOk);
 
-      //allows ToResult<TValue> and ToResult<TState, TValue> to share an implementation.
+      //allows AsResult<TValue> and AsResult<TState, TValue> to share an implementation.
       static TValue WrapFactoryCallback(Func<TValue> callback) => callback();
     }
 
     /// <summary>
-    /// Converts a <see cref="Result"/> to a <see cref="Result{TValue}"/>, copying over Statement and any Failure information from source result.
+    /// Converts a <see cref="Result"/> to a <see cref="Result{TValue}"/>, wrapping Failure and Statement objects of the source result.
     /// If source <see cref="Result"/> is in Ok state, the returned <see cref="Result{TValue}"/> will be in Ok state with the result of value function as value.
     /// If source <see cref="Result"/> is in Fail state, the returned <see cref="Result{TValue}"/> will be in Fail state with the same <see cref="Failure"/> information.
     /// </summary>
@@ -50,20 +49,23 @@ public static partial class ResultConversionExtensions
     /// <param name="valueFuncOnOk">The function used to generate value if source result in Ok state.</param>
     /// <param name="state">Argument value to pass into value function.</param>
     /// <returns></returns>
-    public Result<TValue> ToResult<TState, TValue>(
+    public Result<TValue> AsResult<TState, TValue>(
       Func<TState, TValue> valueFuncOnOk,
       TState state)
       where TValue : notnull
     {
       return result.Map(
-        static (okResult, state) => Result<TValue>.Ok(state.OkFactory(state.OriginalState))
-          .WithStatementsFrom(okResult),
-        static (failResult, _) => Result<TValue>.Fail(failResult, false),
+        static (okResult, state) => new Result<TValue>(
+          true,
+          state.OkFactory(state.OriginalState),
+          null,
+          okResult.PeekStatements()),
+        static (failResult, _) => Result<TValue>.Fail(failResult),
         new { OkFactory = valueFuncOnOk, OriginalState = state });
     }
 
     /// <summary>
-    /// Converts a <see cref="Result"/> to a <see cref="Result{TValue}"/>, copying over Statement and any Failure information from source result.
+    /// Converts a <see cref="Result"/> to a <see cref="Result{TValue}"/>, wrapping Failure and Statement objects of the source result.
     /// If source <see cref="Result"/> is in Ok state, the returned <see cref="Result{TValue}"/> will be in Ok state with the result of value function as value.
     /// If source <see cref="Result"/> is in Fail state, the returned <see cref="Result{TValue}"/> will be in Fail state with the same <see cref="Failure"/> information.
     /// </summary>
@@ -71,19 +73,19 @@ public static partial class ResultConversionExtensions
     /// <param name="valueFuncOnOk">The function used to generate value if source result in Ok state.</param>
     /// <param name="ct"></param>
     /// <returns></returns>
-    public Task<Result<TValue>> ToResultAsync<TValue>(
+    public Task<Result<TValue>> AsResultAsync<TValue>(
       Func<CancellationToken, Task<TValue>> valueFuncOnOk,
       CancellationToken ct)
       where TValue : notnull
     {
-      return result.ToResultAsync(WrapFactoryCallback, valueFuncOnOk, ct);
+      return result.AsResultAsync(WrapFactoryCallback, valueFuncOnOk, ct);
 
-      //allows ToResultAsync<TValue> and ToResultAsync<TState, TValue> to share an implementation.
+      //allows AsResultAsync<TValue> and AsResultAsync<TState, TValue> to share an implementation.
       static Task<TValue> WrapFactoryCallback(Func<CancellationToken, Task<TValue>> callback, CancellationToken ct) => callback(ct);
     }
 
     /// <summary>
-    /// Converts a <see cref="Result"/> to a <see cref="Result{TValue}"/>, copying over Statement and any Failure information from source result.
+    /// Converts a <see cref="Result"/> to a <see cref="Result{TValue}"/>, wrapping Failure and Statement objects of the source result.
     /// If source <see cref="Result"/> is in Ok state, the returned <see cref="Result{TValue}"/> will be in Ok state with the result of value function as value.
     /// If source <see cref="Result"/> is in Fail state, the returned <see cref="Result{TValue}"/> will be in Fail state with the same <see cref="Failure"/> information.
     /// </summary>
@@ -93,17 +95,19 @@ public static partial class ResultConversionExtensions
     /// <param name="state">Argument value to pass into value function.</param>
     /// <param name="ct"></param>
     /// <returns></returns>
-    public Task<Result<TValue>> ToResultAsync<TState, TValue>(
+    public Task<Result<TValue>> AsResultAsync<TState, TValue>(
       Func<TState, CancellationToken, Task<TValue>> valueFuncOnOk,
       TState state,
       CancellationToken ct)
       where TValue : notnull
     {
       return result.MapAsync(
-        static async (okResult, state, ct) => Result<TValue>
-          .Ok(await state.OkFactory(state.OriginalState, ct).ConfigureAwait(false))
-          .WithStatementsFrom(okResult),
-        static (failResult, _, _) => Task.FromResult(Result<TValue>.Fail(failResult, false)),
+        static async (okResult, state, ct) => new Result<TValue>(
+          true,
+          await state.OkFactory(state.OriginalState, ct).ConfigureAwait(false),
+          null,
+          okResult.PeekStatements()),
+        static (failResult, _, _) => Task.FromResult(Result<TValue>.Fail(failResult)),
         new { OkFactory = valueFuncOnOk, OriginalState = state },
         ct);
     }
@@ -112,37 +116,34 @@ public static partial class ResultConversionExtensions
   extension<TSourceValue>(Result<TSourceValue> result) where TSourceValue : notnull
   {
     /// <summary>
-    /// Converts a <see cref="Result{TSourceValue}"/> to a <see cref="Result"/>, copying over Statement and any Failure information from source result.
-    /// If source <see cref="Result{TSourceValue}"/> is in Fail state, the returned <see cref="Result"/> will be in Fail state with the same <see cref="Failure"/> information.
+    /// Returns a <see cref="Result"/> that wraps the same state, Failure and Statements as the source <see cref="Result{TSourceValue}"/>.
     /// </summary>
     /// <returns></returns>
-    public Result ToResult()
+    public Result AsResult()
     {
-      return result.Map<TSourceValue, Result>(
-        okResult => Result.Ok().WithStatementsFrom(okResult),
-        failResult => Result.Fail(failResult, false));
+      return new(result.IsOk, result.Failure, result.PeekStatements());
     }
 
     /// <summary>
-    /// Converts a <see cref="Result{TSourceValue}"/> to a <see cref="Result{TTargetValue}"/>, copying over Statement and any Failure information from source result.
+    /// Converts a <see cref="Result{TSourceValue}"/> to a <see cref="Result{TTargetValue}"/>, wrapping Failure and Statement objects of the source result.
     /// If source <see cref="Result{TSourceValue}"/> is in Ok state, the returned <see cref="Result{TTargetValue}"/> will be in Ok state with the result of value function as value.
     /// If source <see cref="Result{TSourceValue}"/> is in Fail state, the returned <see cref="Result{TTargetValue}"/> will be in Fail state with the same <see cref="Failure"/> information.
     /// </summary>
     /// <typeparam name="TTargetValue"></typeparam>
     /// <param name="valueFuncOnOk">The function used to generate value if source result in Ok state.</param>
     /// <returns></returns>
-    public Result<TTargetValue> ToResult<TTargetValue>(
+    public Result<TTargetValue> AsResult<TTargetValue>(
       Func<TSourceValue, TTargetValue> valueFuncOnOk)
       where TTargetValue : notnull
     {
-      return result.ToResult(WrapFactoryCallback, valueFuncOnOk);
+      return result.AsResult(WrapFactoryCallback, valueFuncOnOk);
 
-      //allows ToResult<TSourceValue, TTargetValue> and ToResult<TSourceValue, TState, TTargetValue> to share an implementation.
+      //allows AsResult<TSourceValue, TTargetValue> and AsResult<TSourceValue, TState, TTargetValue> to share an implementation.
       static TTargetValue WrapFactoryCallback(TSourceValue value, Func<TSourceValue, TTargetValue> callback) => callback(value);
     }
 
     /// <summary>
-    /// Converts a <see cref="Result{TSourceValue}"/> to a <see cref="Result{TTargetValue}"/>, copying over Statement and any Failure information from source result.
+    /// Converts a <see cref="Result{TSourceValue}"/> to a <see cref="Result{TTargetValue}"/>, wrapping Failure and Statement objects of the source result.
     /// If source <see cref="Result{TSourceValue}"/> is in Ok state, the returned <see cref="Result{TTargetValue}"/> will be in Ok state with the result of value function as value.
     /// If source <see cref="Result{TSourceValue}"/> is in Fail state, the returned <see cref="Result{TTargetValue}"/> will be in Fail state with the same <see cref="Failure"/> information.
     /// </summary>
@@ -151,23 +152,23 @@ public static partial class ResultConversionExtensions
     /// <param name="valueFuncOnOk">The function used to generate value if source result in Ok state.</param>
     /// <param name="state">Argument value to pass into value function.</param>
     /// <returns></returns>
-    public Result<TTargetValue> ToResult<TState, TTargetValue>(
+    public Result<TTargetValue> AsResult<TState, TTargetValue>(
       Func<TSourceValue, TState, TTargetValue> valueFuncOnOk,
       TState state)
       where TTargetValue : notnull
     {
       return result.Map(
-        static (okResult, state) => Result<TTargetValue>.Ok(
-          state.OkFactory(
-            okResult.Value!,
-            state.OriginalState))
-          .WithStatementsFrom(okResult),
-        static (failResult, _) => Result<TTargetValue>.Fail(failResult, false),
+        static (okResult, state) => new Result<TTargetValue>(
+          true,
+          state.OkFactory(okResult.Value!, state.OriginalState),
+          null,
+          okResult.PeekStatements()),
+        static (failResult, _) => Result<TTargetValue>.Fail(failResult),
         new { OkFactory = valueFuncOnOk, OriginalState = state });
     }
 
     /// <summary>
-    /// Converts a <see cref="Result{TSourceValue}"/> to a <see cref="Result{TTargetValue}"/>, copying over Statement and any Failure information from source result.
+    /// Converts a <see cref="Result{TSourceValue}"/> to a <see cref="Result{TTargetValue}"/>, wrapping Failure and Statement objects of the source result.
     /// If source <see cref="Result{TSourceValue}"/> is in Ok state, the returned <see cref="Result{TTargetValue}"/> will be in Ok state with the result of value function as value.
     /// If source <see cref="Result{TSourceValue}"/> is in Fail state, the returned <see cref="Result{TTargetValue}"/> will be in Fail state with the same <see cref="Failure"/> information.
     /// </summary>
@@ -175,19 +176,19 @@ public static partial class ResultConversionExtensions
     /// <param name="valueFuncOnOk">The function used to generate value if source result in Ok state.</param>
     /// <param name="ct"></param>
     /// <returns></returns>
-    public Task<Result<TTargetValue>> ToResultAsync<TTargetValue>(
+    public Task<Result<TTargetValue>> AsResultAsync<TTargetValue>(
       Func<TSourceValue, CancellationToken, Task<TTargetValue>> valueFuncOnOk,
       CancellationToken ct)
       where TTargetValue : notnull
     {
-      return result.ToResultAsync(WrapFactoryCallback, valueFuncOnOk, ct);
+      return result.AsResultAsync(WrapFactoryCallback, valueFuncOnOk, ct);
 
-      //allows ToResultAsync<TSourceValue, TTargetValue> and ToResultAsync<TSourceValue, TState, TTargetValue> to share an implementation.
+      //allows AsResultAsync<TSourceValue, TTargetValue> and AsResultAsync<TSourceValue, TState, TTargetValue> to share an implementation.
       static Task<TTargetValue> WrapFactoryCallback(TSourceValue value, Func<TSourceValue, CancellationToken, Task<TTargetValue>> callback, CancellationToken ct) => callback(value, ct);
     }
 
     /// <summary>
-    /// Converts a <see cref="Result{TSourceValue}"/> to a <see cref="Result{TTargetValue}"/>, copying over Statement and any Failure information from source result.
+    /// Converts a <see cref="Result{TSourceValue}"/> to a <see cref="Result{TTargetValue}"/>, wrapping Failure and Statement objects of the source result.
     /// If source <see cref="Result{TSourceValue}"/> is in Ok state, the returned <see cref="Result{TTargetValue}"/> will be in Ok state with the result of value function as value.
     /// If source <see cref="Result{TSourceValue}"/> is in Fail state, the returned <see cref="Result{TTargetValue}"/> will be in Fail state with the same <see cref="Failure"/> information.
     /// </summary>
@@ -197,20 +198,19 @@ public static partial class ResultConversionExtensions
     /// <param name="state">Argument value to pass into value function.</param>
     /// <param name="ct"></param>
     /// <returns></returns>
-    public Task<Result<TTargetValue>> ToResultAsync<TState, TTargetValue>(
+    public Task<Result<TTargetValue>> AsResultAsync<TState, TTargetValue>(
       Func<TSourceValue, TState, CancellationToken, Task<TTargetValue>> valueFuncOnOk,
       TState state,
       CancellationToken ct)
       where TTargetValue : notnull
     {
       return result.MapAsync(
-        static async (okResult, state, ct) => Result<TTargetValue>.Ok(
-          await state.OkFactory(
-            okResult.Value!,
-            state.OriginalState,
-            ct).ConfigureAwait(false))
-          .WithStatementsFrom(okResult),
-        static (failResult, _, _) => Task.FromResult(Result<TTargetValue>.Fail(failResult, false)),
+        static async (okResult, state, ct) => new Result<TTargetValue>(
+          true,
+          await state.OkFactory(okResult.Value!, state.OriginalState, ct).ConfigureAwait(false),
+          null,
+          okResult.PeekStatements()),
+        static (failResult, _, _) => Task.FromResult(Result<TTargetValue>.Fail(failResult)),
         new { OkFactory = valueFuncOnOk, OriginalState = state },
         ct);
     }
@@ -218,18 +218,14 @@ public static partial class ResultConversionExtensions
 
   extension<TValue>(Result<TValue, Failure> result) where TValue : notnull
   {
-    public Result ToResult()
+    public Result AsResult()
     {
-      return result.Map<TValue, Failure, Result>(
-        okResult => Result.Ok().WithStatementsFrom(okResult),
-        failResult => Result.Fail(failResult, false));
+      return new(result.IsOk, result.Failure, result.PeekStatements());
     }
 
-    public Result<TValue> ToResultOfTValue()
+    public Result<TValue> AsResultOfTValue()
     {
-      return result.Map<TValue, Failure, Result<TValue>>(
-        okResult => Result<TValue>.Ok(result.Value!).WithStatementsFrom(okResult),
-        failResult => Result<TValue>.Fail(failResult, false));
+      return new(result.IsOk, result.Value, result.Failure, result.PeekStatements());
     }
   }
 }

--- a/src/ModResults/[Core]/BaseResult.cs
+++ b/src/ModResults/[Core]/BaseResult.cs
@@ -55,7 +55,7 @@ public abstract class BaseResult : IModResult
   /// Gets the current collection of statements if it has been initialized.
   /// </summary>
   /// <returns>The current <see cref="Statements"/> instance if it has been initialized; otherwise, <see langword="null"/>.</returns>
-  public Statements? PeekStatements()
+  internal Statements? PeekStatements()
   {
     return _statements;
   }

--- a/src/ModResults/[Core]/BaseResult.cs
+++ b/src/ModResults/[Core]/BaseResult.cs
@@ -52,6 +52,15 @@ public abstract class BaseResult : IModResult
   }
 
   /// <summary>
+  /// Gets the current collection of statements if it has been initialized.
+  /// </summary>
+  /// <returns>The current <see cref="Statements"/> instance if it has been initialized; otherwise, <see langword="null"/>.</returns>
+  public Statements? PeekStatements()
+  {
+    return _statements;
+  }
+
+  /// <summary>
   /// Determines whether the current result contains any facts under statements property without initializing the statements property or its facts property.
   /// </summary>
   /// <returns><see langword="true"/> if the result contains at least one fact; otherwise, <see langword="false"/>.</returns>

--- a/src/ModResults/[Core]/BaseResultExtensions.cs
+++ b/src/ModResults/[Core]/BaseResultExtensions.cs
@@ -40,7 +40,7 @@ public static class BaseResultExtensions
       string code,
       StringComparison comparisonType = Definitions.DefaultComparisonType)
     {
-      return result.HasFacts() && result.Statements.Facts.Any(f => f.HasCode(code, comparisonType));
+      return result.PeekStatements()?.PeekFacts()?.Any(f => f.HasCode(code, comparisonType)) ?? false;
     }
 
     /// <summary>
@@ -76,11 +76,7 @@ public static class BaseResultExtensions
       string code,
       StringComparison comparisonType)
     {
-      if (result.HasFacts())
-      {
-        return result.Statements.Facts.Where(f => f.HasCode(code, comparisonType));
-      }
-      return [];
+      return result.PeekStatements()?.PeekFacts()?.Where(f => f.HasCode(code, comparisonType)) ?? [];
     }
 
     /// <summary>
@@ -93,7 +89,7 @@ public static class BaseResultExtensions
       string code,
       StringComparison comparisonType = Definitions.DefaultComparisonType)
     {
-      return result.HasWarnings() && result.Statements.Warnings.Any(p => p.HasCode(code, comparisonType));
+      return result.PeekStatements()?.PeekWarnings()?.Any(p => p.HasCode(code, comparisonType)) ?? false;
     }
 
     /// <summary>
@@ -129,11 +125,7 @@ public static class BaseResultExtensions
       string code,
       StringComparison comparisonType)
     {
-      if (result.HasWarnings())
-      {
-        return result.Statements.Warnings.Where(w => w.HasCode(code, comparisonType));
-      }
-      return [];
+      return result.PeekStatements()?.PeekWarnings()?.Where(w => w.HasCode(code, comparisonType)) ?? [];
     }
   }
 }

--- a/src/ModResults/[Core]/Statements.cs
+++ b/src/ModResults/[Core]/Statements.cs
@@ -23,6 +23,15 @@ public sealed class Statements
     return _warnings is not null && _warnings.Count > 0;
   }
 
+  /// <summary>
+  /// Gets the current collection of warnings if it has been initialized.
+  /// </summary>
+  /// <returns>The current <see cref="Warning"/> list instance if it has been initialized; otherwise, <see langword="null"/>.</returns>
+  internal List<Warning>? PeekWarnings()
+  {
+    return _warnings;
+  }
+
   private List<Fact>? _facts;
   private List<Fact> GetFacts()
   {
@@ -42,6 +51,15 @@ public sealed class Statements
   public bool HasFacts()
   {
     return _facts is not null && _facts.Count > 0;
+  }
+
+  /// <summary>
+  /// Gets the current collection of facts if it has been initialized.
+  /// </summary>
+  /// <returns>The current <see cref="Fact"/> list instance if it has been initialized; otherwise, <see langword="null"/>.</returns>
+  internal List<Fact>? PeekFacts()
+  {
+    return _facts;
   }
 
   /// <summary>

--- a/tests/ModResults.Tests/FailureResultTests.cs
+++ b/tests/ModResults.Tests/FailureResultTests.cs
@@ -1,0 +1,136 @@
+﻿namespace ModResults.Tests;
+
+public class FailureResultTests
+{
+  private readonly Fact _fact1, _fact2;
+  private readonly Warning _warning1;
+  private readonly Error _error1, _error2, _error5;
+
+  public FailureResultTests()
+  {
+    _fact1 = new Fact();
+    _fact2 = new Fact("Fact 2", "F2");
+    _warning1 = new Warning();
+    _error1 = new Error();
+    _error2 = new Error("Error 2", code: "E2");
+    _error5 = new Error(new ApplicationException("Error 5", new ArgumentException("Error 5 Inner")));
+  }
+
+  [Fact]
+  public void FailureResultFromFailedResultOfT()
+  {
+    // Arrange
+    var facts = new List<Fact> { _fact1, _fact2 };
+    var warnings = new List<Warning> { _warning1 };
+    var errors = new List<Error> { _error1, _error2, _error5 };
+    var resultOfT = new Result<ValueStruct>(
+      false,
+      default,
+      new Failure(FailureType.Forbidden, errors),
+      new Statements(facts, warnings));
+    var result = FailureResult.FromResult(resultOfT);
+
+    // Act
+    var isOk = result.IsOk;
+    var isFailed = result.IsFailed;
+    var failure = result.Failure;
+
+    // Assert
+    Assert.False(isOk);
+    Assert.True(isFailed);
+    Assert.NotNull(failure);
+    Assert.Equal(3, failure?.Errors.Count);
+    Assert.Equal(string.Empty, failure?.Errors[0].Message);
+    Assert.Equal("Error 2", failure?.Errors[1].Message);
+    Assert.Equal("Error 5", failure?.Errors[2].Message);
+    Assert.Equal(2, result.Statements.Facts.Count);
+    Assert.Equal(string.Empty, result.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", result.Statements.Facts[1].Message);
+    Assert.Single(result.Statements.Warnings);
+    Assert.Equal(string.Empty, result.Statements.Warnings[0].Message);
+    Assert.True(result.IsFailedWith(FailureType.Forbidden));
+    Assert.False(result.IsFailedWith(FailureType.Unspecified));
+    Assert.True(result.IsFailedWith("E2"));
+    Assert.False(result.IsFailedWith("e2"));
+    Assert.True(result.IsFailedWith<ApplicationException>());
+    Assert.False(result.IsFailedWith<Exception>());
+    Assert.False(result.IsFailedWith(typeof(Exception)));
+    Assert.True(result.IsFailedWith<Exception>(true));
+    Assert.True(result.IsFailedWith(typeof(Exception), true));
+  }
+
+  [Fact]
+  public void FailureResultFromFailedResultOfTWithEmptyErrors()
+  {
+    // Arrange
+    var facts = new List<Fact> { _fact1, _fact2 };
+    var warnings = new List<Warning> { _warning1 };
+    var resultOfT = new Result<ValueStruct>(
+      false,
+      default,
+      new Failure(FailureType.Forbidden, null),
+      new Statements(facts, warnings));
+    var result = FailureResult.FromResult(resultOfT);
+
+    // Act
+    var isOk = result.IsOk;
+    var isFailed = result.IsFailed;
+    var failure = result.Failure;
+
+    // Assert
+    Assert.False(isOk);
+    Assert.True(isFailed);
+    Assert.NotNull(failure);
+    Assert.False(failure.HasErrors());
+    Assert.Equal(2, result.Statements.Facts.Count);
+    Assert.Equal(string.Empty, result.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", result.Statements.Facts[1].Message);
+    Assert.Single(result.Statements.Warnings);
+    Assert.Equal(string.Empty, result.Statements.Warnings[0].Message);
+    Assert.True(result.IsFailedWith(FailureType.Forbidden));
+    Assert.False(result.IsFailedWith(FailureType.Unspecified));
+    Assert.False(result.IsFailedWith("E2"));
+    Assert.False(result.IsFailedWith("e2"));
+    Assert.False(result.IsFailedWith<ApplicationException>());
+    Assert.False(result.IsFailedWith<Exception>());
+    Assert.False(result.IsFailedWith(typeof(Exception)));
+    Assert.False(result.IsFailedWith<Exception>(true));
+    Assert.False(result.IsFailedWith(typeof(Exception), true));
+  }
+
+  [Fact]
+  public void FailureResultFromOkResultOfT()
+  {
+    // Arrange
+    var facts = new List<Fact> { _fact1, _fact2 };
+    var warnings = new List<Warning> { _warning1 };
+    var resultOfT = new Result<ValueStruct>(
+      true,
+      new ValueStruct() { Number = 42, String = "Meaning of life." },
+      null,
+      new Statements(facts, warnings));
+
+    // Act
+    var result = FailureResult.FromResult(resultOfT);
+
+    // Assert
+    Assert.False(result.IsOk);
+    Assert.True(result.IsFailed);
+    Assert.NotNull(result.Failure);
+    Assert.Empty(result.Failure.Errors);
+    Assert.Equal(2, result.Statements.Facts.Count);
+    Assert.Equal(string.Empty, result.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", result.Statements.Facts[1].Message);
+    Assert.Single(result.Statements.Warnings);
+    Assert.Equal(string.Empty, result.Statements.Warnings[0].Message);
+    Assert.False(result.IsFailedWith(FailureType.Forbidden));
+    Assert.True(result.IsFailedWith(FailureType.Unspecified));
+    Assert.False(result.IsFailedWith("E2"));
+    Assert.False(result.IsFailedWith("e2"));
+    Assert.False(result.IsFailedWith<ApplicationException>());
+    Assert.False(result.IsFailedWith<Exception>());
+    Assert.False(result.IsFailedWith(typeof(Exception)));
+    Assert.False(result.IsFailedWith<Exception>(true));
+    Assert.False(result.IsFailedWith(typeof(Exception), true));
+  }
+}

--- a/tests/ModResults.Tests/FailureResultTests.cs
+++ b/tests/ModResults.Tests/FailureResultTests.cs
@@ -110,7 +110,7 @@ public class FailureResultTests
       default,
       new Failure(FailureType.Forbidden, errors),
       new Statements(facts, warnings));
-    var result = resultOfT.ToFailureResult();
+    var result = FailureResult.From(resultOfT, false);
 
     // Act
     var isOk = result.IsOk;
@@ -153,7 +153,7 @@ public class FailureResultTests
       default,
       new Failure(FailureType.Forbidden, errors),
       new Statements(facts, warnings));
-    var result = resultOfT.AsFailureResult();
+    var result = FailureResult.From(resultOfT);
 
     // Act
     var isOk = result.IsOk;
@@ -195,7 +195,7 @@ public class FailureResultTests
       default,
       new Failure(FailureType.Forbidden, null),
       new Statements(facts, warnings));
-    var result = resultOfT.ToFailureResult();
+    var result = FailureResult.From(resultOfT, false);
 
     // Act
     var isOk = result.IsOk;
@@ -234,7 +234,7 @@ public class FailureResultTests
       default,
       new Failure(FailureType.Forbidden, null),
       new Statements(facts, warnings));
-    var result = resultOfT.AsFailureResult();
+    var result = FailureResult.From(resultOfT);
 
     // Act
     var isOk = result.IsOk;
@@ -275,7 +275,7 @@ public class FailureResultTests
       new Statements(facts, warnings));
 
     // Act
-    var result = resultOfT.ToFailureResult();
+    var result = FailureResult.From(resultOfT, false);
 
     // Assert
     Assert.False(result.IsOk);
@@ -311,7 +311,7 @@ public class FailureResultTests
       new Statements(facts, warnings));
 
     // Act
-    var result = resultOfT.AsFailureResult();
+    var result = FailureResult.From(resultOfT);
 
     // Assert
     Assert.False(result.IsOk);

--- a/tests/ModResults.Tests/FailureResultTests.cs
+++ b/tests/ModResults.Tests/FailureResultTests.cs
@@ -17,6 +17,88 @@ public class FailureResultTests
   }
 
   [Fact]
+  public void FailureResultAsFailedResultOfT()
+  {
+    // Arrange
+    var facts = new List<Fact> { _fact1, _fact2 };
+    var warnings = new List<Warning> { _warning1 };
+    var errors = new List<Error> { _error1, _error2, _error5 };
+    var failureResult = new FailureResult(
+      new Failure(FailureType.Forbidden, errors),
+      new Statements(facts, warnings));
+    Result<ValueStruct> resultOfT = failureResult;
+
+    // Act
+    var isOk = resultOfT.IsOk;
+    var isFailed = resultOfT.IsFailed;
+    var failure = resultOfT.Failure;
+
+    // Assert
+    Assert.False(isOk);
+    Assert.True(isFailed);
+    Assert.NotNull(failure);
+    Assert.Equal(3, failure?.Errors.Count);
+    Assert.Equal(string.Empty, failure?.Errors[0].Message);
+    Assert.Equal("Error 2", failure?.Errors[1].Message);
+    Assert.Equal("Error 5", failure?.Errors[2].Message);
+    Assert.Equal(2, resultOfT.Statements.Facts.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", resultOfT.Statements.Facts[1].Message);
+    Assert.Single(resultOfT.Statements.Warnings);
+    Assert.Equal(string.Empty, resultOfT.Statements.Warnings[0].Message);
+    Assert.True(resultOfT.IsFailedWith(FailureType.Forbidden));
+    Assert.False(resultOfT.IsFailedWith(FailureType.Unspecified));
+    Assert.True(resultOfT.IsFailedWith("E2"));
+    Assert.False(resultOfT.IsFailedWith("e2"));
+    Assert.True(resultOfT.IsFailedWith<ApplicationException>());
+    Assert.False(resultOfT.IsFailedWith<Exception>());
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception)));
+    Assert.True(resultOfT.IsFailedWith<Exception>(true));
+    Assert.True(resultOfT.IsFailedWith(typeof(Exception), true));
+  }
+
+  [Fact]
+  public void FailureResultAsFailedResult()
+  {
+    // Arrange
+    var facts = new List<Fact> { _fact1, _fact2 };
+    var warnings = new List<Warning> { _warning1 };
+    var errors = new List<Error> { _error1, _error2, _error5 };
+    var failureResult = new FailureResult(
+      new Failure(FailureType.Forbidden, errors),
+      new Statements(facts, warnings));
+    Result result = failureResult;
+
+    // Act
+    var isOk = result.IsOk;
+    var isFailed = result.IsFailed;
+    var failure = result.Failure;
+
+    // Assert
+    Assert.False(isOk);
+    Assert.True(isFailed);
+    Assert.NotNull(failure);
+    Assert.Equal(3, failure?.Errors.Count);
+    Assert.Equal(string.Empty, failure?.Errors[0].Message);
+    Assert.Equal("Error 2", failure?.Errors[1].Message);
+    Assert.Equal("Error 5", failure?.Errors[2].Message);
+    Assert.Equal(2, result.Statements.Facts.Count);
+    Assert.Equal(string.Empty, result.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", result.Statements.Facts[1].Message);
+    Assert.Single(result.Statements.Warnings);
+    Assert.Equal(string.Empty, result.Statements.Warnings[0].Message);
+    Assert.True(result.IsFailedWith(FailureType.Forbidden));
+    Assert.False(result.IsFailedWith(FailureType.Unspecified));
+    Assert.True(result.IsFailedWith("E2"));
+    Assert.False(result.IsFailedWith("e2"));
+    Assert.True(result.IsFailedWith<ApplicationException>());
+    Assert.False(result.IsFailedWith<Exception>());
+    Assert.False(result.IsFailedWith(typeof(Exception)));
+    Assert.True(result.IsFailedWith<Exception>(true));
+    Assert.True(result.IsFailedWith(typeof(Exception), true));
+  }
+
+  [Fact]
   public void FailureResultFromFailedResultOfT()
   {
     // Arrange
@@ -28,7 +110,50 @@ public class FailureResultTests
       default,
       new Failure(FailureType.Forbidden, errors),
       new Statements(facts, warnings));
-    var result = FailureResult.FromResult(resultOfT);
+    var result = resultOfT.ToFailureResult();
+
+    // Act
+    var isOk = result.IsOk;
+    var isFailed = result.IsFailed;
+    var failure = result.Failure;
+
+    // Assert
+    Assert.False(isOk);
+    Assert.True(isFailed);
+    Assert.NotNull(failure);
+    Assert.Equal(3, failure?.Errors.Count);
+    Assert.Equal(string.Empty, failure?.Errors[0].Message);
+    Assert.Equal("Error 2", failure?.Errors[1].Message);
+    Assert.Equal("Error 5", failure?.Errors[2].Message);
+    Assert.Equal(2, result.Statements.Facts.Count);
+    Assert.Equal(string.Empty, result.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", result.Statements.Facts[1].Message);
+    Assert.Single(result.Statements.Warnings);
+    Assert.Equal(string.Empty, result.Statements.Warnings[0].Message);
+    Assert.True(result.IsFailedWith(FailureType.Forbidden));
+    Assert.False(result.IsFailedWith(FailureType.Unspecified));
+    Assert.True(result.IsFailedWith("E2"));
+    Assert.False(result.IsFailedWith("e2"));
+    Assert.True(result.IsFailedWith<ApplicationException>());
+    Assert.False(result.IsFailedWith<Exception>());
+    Assert.False(result.IsFailedWith(typeof(Exception)));
+    Assert.True(result.IsFailedWith<Exception>(true));
+    Assert.True(result.IsFailedWith(typeof(Exception), true));
+  }
+
+  [Fact]
+  public void FailedResultOfTAsFailureResult()
+  {
+    // Arrange
+    var facts = new List<Fact> { _fact1, _fact2 };
+    var warnings = new List<Warning> { _warning1 };
+    var errors = new List<Error> { _error1, _error2, _error5 };
+    var resultOfT = new Result<ValueStruct>(
+      false,
+      default,
+      new Failure(FailureType.Forbidden, errors),
+      new Statements(facts, warnings));
+    var result = resultOfT.AsFailureResult();
 
     // Act
     var isOk = result.IsOk;
@@ -70,7 +195,46 @@ public class FailureResultTests
       default,
       new Failure(FailureType.Forbidden, null),
       new Statements(facts, warnings));
-    var result = FailureResult.FromResult(resultOfT);
+    var result = resultOfT.ToFailureResult();
+
+    // Act
+    var isOk = result.IsOk;
+    var isFailed = result.IsFailed;
+    var failure = result.Failure;
+
+    // Assert
+    Assert.False(isOk);
+    Assert.True(isFailed);
+    Assert.NotNull(failure);
+    Assert.False(failure.HasErrors());
+    Assert.Equal(2, result.Statements.Facts.Count);
+    Assert.Equal(string.Empty, result.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", result.Statements.Facts[1].Message);
+    Assert.Single(result.Statements.Warnings);
+    Assert.Equal(string.Empty, result.Statements.Warnings[0].Message);
+    Assert.True(result.IsFailedWith(FailureType.Forbidden));
+    Assert.False(result.IsFailedWith(FailureType.Unspecified));
+    Assert.False(result.IsFailedWith("E2"));
+    Assert.False(result.IsFailedWith("e2"));
+    Assert.False(result.IsFailedWith<ApplicationException>());
+    Assert.False(result.IsFailedWith<Exception>());
+    Assert.False(result.IsFailedWith(typeof(Exception)));
+    Assert.False(result.IsFailedWith<Exception>(true));
+    Assert.False(result.IsFailedWith(typeof(Exception), true));
+  }
+
+  [Fact]
+  public void FailedResultOfTWithEmptyErrorsAsFailureResult()
+  {
+    // Arrange
+    var facts = new List<Fact> { _fact1, _fact2 };
+    var warnings = new List<Warning> { _warning1 };
+    var resultOfT = new Result<ValueStruct>(
+      false,
+      default,
+      new Failure(FailureType.Forbidden, null),
+      new Statements(facts, warnings));
+    var result = resultOfT.AsFailureResult();
 
     // Act
     var isOk = result.IsOk;
@@ -111,7 +275,43 @@ public class FailureResultTests
       new Statements(facts, warnings));
 
     // Act
-    var result = FailureResult.FromResult(resultOfT);
+    var result = resultOfT.ToFailureResult();
+
+    // Assert
+    Assert.False(result.IsOk);
+    Assert.True(result.IsFailed);
+    Assert.NotNull(result.Failure);
+    Assert.Empty(result.Failure.Errors);
+    Assert.Equal(2, result.Statements.Facts.Count);
+    Assert.Equal(string.Empty, result.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", result.Statements.Facts[1].Message);
+    Assert.Single(result.Statements.Warnings);
+    Assert.Equal(string.Empty, result.Statements.Warnings[0].Message);
+    Assert.False(result.IsFailedWith(FailureType.Forbidden));
+    Assert.True(result.IsFailedWith(FailureType.Unspecified));
+    Assert.False(result.IsFailedWith("E2"));
+    Assert.False(result.IsFailedWith("e2"));
+    Assert.False(result.IsFailedWith<ApplicationException>());
+    Assert.False(result.IsFailedWith<Exception>());
+    Assert.False(result.IsFailedWith(typeof(Exception)));
+    Assert.False(result.IsFailedWith<Exception>(true));
+    Assert.False(result.IsFailedWith(typeof(Exception), true));
+  }
+
+  [Fact]
+  public void OkResultOfTAsFailureResult()
+  {
+    // Arrange
+    var facts = new List<Fact> { _fact1, _fact2 };
+    var warnings = new List<Warning> { _warning1 };
+    var resultOfT = new Result<ValueStruct>(
+      true,
+      new ValueStruct() { Number = 42, String = "Meaning of life." },
+      null,
+      new Statements(facts, warnings));
+
+    // Act
+    var result = resultOfT.AsFailureResult();
 
     // Assert
     Assert.False(result.IsOk);

--- a/tests/ModResults.Tests/ResultConversionAsTests.cs
+++ b/tests/ModResults.Tests/ResultConversionAsTests.cs
@@ -1,0 +1,532 @@
+﻿namespace ModResults.Tests;
+
+public class ResultConversionAsTests
+{
+  private readonly Fact _fact1, _fact2, _fact3;
+  private readonly Warning _warning1, _warning2, _warning3;
+  private readonly Error _error1, _error2;
+  private readonly InvalidOperationException _ex1;
+  private readonly ApplicationException _ex2;
+
+  public ResultConversionAsTests()
+  {
+    _fact1 = new Fact();
+    _fact2 = new Fact("Fact 2", "F2");
+    _fact3 = new Fact("Fact 3", "F3");
+    _warning1 = new Warning();
+    _warning2 = new Warning("Warning 2", "W2");
+    _warning3 = new Warning("Warning 3", "W3");
+    _error1 = new Error("Error 1");
+    _error2 = new Error("Error 2", code: "E2");
+    _ex1 = new InvalidOperationException("Error 4");
+    _ex2 = new ApplicationException("Error 5", new ArgumentException("Error 5 Inner"));
+  }
+
+  [Fact]
+  public void BasicOkResultToResultWithValueOnOk()
+  {
+    //Arrange
+    var result = Result.Ok();
+
+    //Act
+    var resultOfT = result.AsResult<ValueClass>(new ValueClass() { Number = 42, String = "Meaning of life." });
+
+    // Assert
+    Assert.True(resultOfT.IsOk);
+    Assert.False(resultOfT.IsFailed);
+    Assert.Null(resultOfT.Failure);
+    Assert.NotNull(resultOfT.Value);
+    Assert.Equal(42, resultOfT.Value.Number);
+    Assert.Equal("Meaning of life.", resultOfT.Value.String);
+    Assert.False(resultOfT.HasFacts());
+    Assert.False(resultOfT.HasWarnings());
+    Assert.False(resultOfT.HasStatements());
+  }
+
+  [Fact]
+  public void OkResultToResultWithValueOnOk()
+  {
+    //Arrange
+    var result = Result.Ok().WithFacts([_fact1, _fact2, _fact3]).WithWarnings([_warning1, _warning2, _warning3]);
+
+    //Act
+    var resultOfT = result.AsResult<ValueClass>(new ValueClass() { Number = 42, String = "Meaning of life." });
+
+    // Assert
+    Assert.True(resultOfT.IsOk);
+    Assert.False(resultOfT.IsFailed);
+    Assert.Null(resultOfT.Failure);
+    Assert.NotNull(resultOfT.Value);
+    Assert.Equal(42, resultOfT.Value.Number);
+    Assert.Equal("Meaning of life.", resultOfT.Value.String);
+    Assert.Equal(3, resultOfT.Statements.Facts.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", resultOfT.Statements.Facts[1].Message);
+    Assert.Equal("Fact 3", resultOfT.Statements.Facts[2].Message);
+    Assert.True(resultOfT.HasFact("F3"));
+    Assert.False(resultOfT.HasFact("f3"));
+    Assert.Equal(3, resultOfT.Statements.Warnings.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Warnings[0].Message);
+    Assert.Equal("Warning 2", resultOfT.Statements.Warnings[1].Message);
+    Assert.Equal("Warning 3", resultOfT.Statements.Warnings[2].Message);
+    Assert.False(resultOfT.IsFailedWith(FailureType.Error));
+    Assert.False(resultOfT.IsFailedWith(FailureType.Unspecified));
+    Assert.False(resultOfT.IsFailedWith("E2"));
+    Assert.False(resultOfT.IsFailedWith("e2"));
+    Assert.False(resultOfT.IsFailedWith<ApplicationException>());
+    Assert.False(resultOfT.IsFailedWith(typeof(InvalidOperationException)));
+    Assert.False(resultOfT.IsFailedWith<InvalidCastException>());
+    Assert.False(resultOfT.IsFailedWith<Exception>());
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception)));
+    Assert.False(resultOfT.IsFailedWith<Exception>(true));
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception), true));
+  }
+
+  [Fact]
+  public void BasicFailedResultToResultWithValueOnOk()
+  {
+    //Arrange
+    var resultOriginal = Result.TimedOut();
+
+    //Act
+    var resultOfT = resultOriginal.AsResult<ValueClass>(new ValueClass() { Number = 42, String = "Meaning of life." });
+
+    // Assert
+    Assert.NotNull(resultOfT);
+    Assert.False(resultOfT.IsOk);
+    Assert.True(resultOfT.IsFailed);
+    Assert.NotNull(resultOfT.Failure);
+    Assert.Null(resultOfT.Value);
+    Assert.False(resultOfT.HasFacts());
+    Assert.False(resultOfT.HasWarnings());
+    Assert.False(resultOfT.HasStatements());
+    Assert.False(resultOfT.Failure.HasErrors());
+  }
+
+  [Fact]
+  public void FailedResultToResultWithValueOnOk()
+  {
+    //Arrange
+    var resultOriginal = Result
+      .Error(
+        _error1,
+        _error2,
+        new Error(_ex1),
+        new Error(_ex2))
+      .WithFacts([_fact1, _fact2, _fact3])
+      .WithWarnings([_warning1, _warning2, _warning3]);
+
+    //Act
+    var resultOfT = resultOriginal.AsResult<ValueClass>(new ValueClass() { Number = 42, String = "Meaning of life." });
+
+    // Assert
+    Assert.NotNull(resultOfT);
+    Assert.False(resultOfT.IsOk);
+    Assert.True(resultOfT.IsFailed);
+    Assert.NotNull(resultOfT.Failure);
+    Assert.Null(resultOfT.Value);
+    Assert.Equal(3, resultOfT.Statements.Facts.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", resultOfT.Statements.Facts[1].Message);
+    Assert.Equal("Fact 3", resultOfT.Statements.Facts[2].Message);
+    Assert.True(resultOfT.HasFact("F3"));
+    Assert.False(resultOfT.HasFact("f3"));
+    Assert.Equal(3, resultOfT.Statements.Warnings.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Warnings[0].Message);
+    Assert.Equal("Warning 2", resultOfT.Statements.Warnings[1].Message);
+    Assert.Equal("Warning 3", resultOfT.Statements.Warnings[2].Message);
+    Assert.Equal(4, resultOfT.Failure.Errors.Count);
+    Assert.Equal("Error 1", resultOfT.Failure.Errors[0].Message);
+    Assert.Equal("Error 2", resultOfT.Failure.Errors[1].Message);
+    Assert.True(resultOfT.IsFailedWith(FailureType.Error));
+    Assert.False(resultOfT.IsFailedWith(FailureType.Unspecified));
+    Assert.False(resultOfT.IsFailedWith("Failure.Error"));
+    Assert.True(resultOfT.IsFailedWith("E2"));
+    Assert.False(resultOfT.IsFailedWith("e2"));
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception)));
+    Assert.True(resultOfT.IsFailedWith<Exception>(true));
+    Assert.True(resultOfT.IsFailedWith<InvalidOperationException>());
+    Assert.True(resultOfT.IsFailedWith<ApplicationException>());
+  }
+
+  [Fact]
+  public void OkResultToResultWithValueFuncOnOk()
+  {
+    //Arrange
+    var resultOriginal = Result.Ok().WithFacts([_fact1, _fact2, _fact3]).WithWarnings([_warning1, _warning2, _warning3]);
+    var item1 = 42;
+    var item2 = "Meaning of life.";
+
+    //Act
+    var resultOfT = resultOriginal.AsResult<ValueClass>(
+      () => new ValueClass() { Number = item1, String = item2 });
+
+    // Assert
+    Assert.True(resultOfT.IsOk);
+    Assert.False(resultOfT.IsFailed);
+    Assert.Null(resultOfT.Failure);
+    Assert.NotNull(resultOfT.Value);
+    Assert.Equal(42, resultOfT.Value.Number);
+    Assert.Equal("Meaning of life.", resultOfT.Value.String);
+    Assert.Equal(3, resultOfT.Statements.Facts.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", resultOfT.Statements.Facts[1].Message);
+    Assert.Equal("Fact 3", resultOfT.Statements.Facts[2].Message);
+    Assert.True(resultOfT.HasFact("F3"));
+    Assert.False(resultOfT.HasFact("f3"));
+    Assert.Equal(3, resultOfT.Statements.Warnings.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Warnings[0].Message);
+    Assert.Equal("Warning 2", resultOfT.Statements.Warnings[1].Message);
+    Assert.Equal("Warning 3", resultOfT.Statements.Warnings[2].Message);
+    Assert.False(resultOfT.IsFailedWith(FailureType.Error));
+    Assert.False(resultOfT.IsFailedWith(FailureType.Unspecified));
+    Assert.False(resultOfT.IsFailedWith("E2"));
+    Assert.False(resultOfT.IsFailedWith("e2"));
+    Assert.False(resultOfT.IsFailedWith<ApplicationException>());
+    Assert.False(resultOfT.IsFailedWith(typeof(InvalidOperationException)));
+    Assert.False(resultOfT.IsFailedWith<InvalidCastException>());
+    Assert.False(resultOfT.IsFailedWith<Exception>());
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception)));
+    Assert.False(resultOfT.IsFailedWith<Exception>(true));
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception), true));
+  }
+
+  [Fact]
+  public void FailedResultToResultWithValueFuncOnOk()
+  {
+    //Arrange
+    var resultOriginal = Result
+      .Error(
+        _error1,
+        _error2,
+        new Error(_ex1),
+        new Error(_ex2))
+      .WithFacts([_fact1, _fact2, _fact3])
+      .WithWarnings([_warning1, _warning2, _warning3]);
+    var item1 = 42;
+    var item2 = "Meaning of life.";
+
+    //Act
+    var resultOfT = resultOriginal.AsResult<ValueClass>(
+      () => new ValueClass() { Number = item1, String = item2 });
+
+    // Assert
+    Assert.NotNull(resultOfT);
+    Assert.False(resultOfT.IsOk);
+    Assert.True(resultOfT.IsFailed);
+    Assert.NotNull(resultOfT.Failure);
+    Assert.Null(resultOfT.Value);
+    Assert.Equal(3, resultOfT.Statements.Facts.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", resultOfT.Statements.Facts[1].Message);
+    Assert.Equal("Fact 3", resultOfT.Statements.Facts[2].Message);
+    Assert.True(resultOfT.HasFact("F3"));
+    Assert.False(resultOfT.HasFact("f3"));
+    Assert.Equal(3, resultOfT.Statements.Warnings.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Warnings[0].Message);
+    Assert.Equal("Warning 2", resultOfT.Statements.Warnings[1].Message);
+    Assert.Equal("Warning 3", resultOfT.Statements.Warnings[2].Message);
+    Assert.Equal(4, resultOfT.Failure.Errors.Count);
+    Assert.Equal("Error 1", resultOfT.Failure.Errors[0].Message);
+    Assert.Equal("Error 2", resultOfT.Failure.Errors[1].Message);
+    Assert.True(resultOfT.IsFailedWith(FailureType.Error));
+    Assert.False(resultOfT.IsFailedWith(FailureType.Unspecified));
+    Assert.False(resultOfT.IsFailedWith("Failure.Error"));
+    Assert.True(resultOfT.IsFailedWith("E2"));
+    Assert.False(resultOfT.IsFailedWith("e2"));
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception)));
+    Assert.True(resultOfT.IsFailedWith<Exception>(true));
+    Assert.True(resultOfT.IsFailedWith<InvalidOperationException>());
+    Assert.True(resultOfT.IsFailedWith<ApplicationException>());
+  }
+
+  [Fact]
+  public void OkResultToResultWithValueFuncOnOkAndState()
+  {
+    //Arrange
+    var resultOriginal = Result.Ok().WithFacts([_fact1, _fact2, _fact3]).WithWarnings([_warning1, _warning2, _warning3]);
+
+    //Act
+    var resultOfT = resultOriginal.AsResult<(int, string), ValueClass>(
+      (state) => new ValueClass() { Number = state.Item1, String = state.Item2 },
+      (42, "Meaning of life."));
+
+    // Assert
+    Assert.True(resultOfT.IsOk);
+    Assert.False(resultOfT.IsFailed);
+    Assert.Null(resultOfT.Failure);
+    Assert.NotNull(resultOfT.Value);
+    Assert.Equal(42, resultOfT.Value.Number);
+    Assert.Equal("Meaning of life.", resultOfT.Value.String);
+    Assert.Equal(3, resultOfT.Statements.Facts.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", resultOfT.Statements.Facts[1].Message);
+    Assert.Equal("Fact 3", resultOfT.Statements.Facts[2].Message);
+    Assert.True(resultOfT.HasFact("F3"));
+    Assert.False(resultOfT.HasFact("f3"));
+    Assert.Equal(3, resultOfT.Statements.Warnings.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Warnings[0].Message);
+    Assert.Equal("Warning 2", resultOfT.Statements.Warnings[1].Message);
+    Assert.Equal("Warning 3", resultOfT.Statements.Warnings[2].Message);
+    Assert.False(resultOfT.IsFailedWith(FailureType.Error));
+    Assert.False(resultOfT.IsFailedWith(FailureType.Unspecified));
+    Assert.False(resultOfT.IsFailedWith("E2"));
+    Assert.False(resultOfT.IsFailedWith("e2"));
+    Assert.False(resultOfT.IsFailedWith<ApplicationException>());
+    Assert.False(resultOfT.IsFailedWith(typeof(InvalidOperationException)));
+    Assert.False(resultOfT.IsFailedWith<InvalidCastException>());
+    Assert.False(resultOfT.IsFailedWith<Exception>());
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception)));
+    Assert.False(resultOfT.IsFailedWith<Exception>(true));
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception), true));
+  }
+
+  [Fact]
+  public void FailedResultToResultWithValueFuncOnOkAndState()
+  {
+    //Arrange
+    var resultOriginal = Result
+      .Error(
+        _error1,
+        _error2,
+        new Error(_ex1),
+        new Error(_ex2))
+      .WithFacts([_fact1, _fact2, _fact3])
+      .WithWarnings([_warning1, _warning2, _warning3]);
+
+    //Act
+    var resultOfT = resultOriginal.AsResult<(int, string), ValueClass>(
+      (state) => new ValueClass() { Number = state.Item1, String = state.Item2 },
+      (42, "Meaning of life."));
+
+    // Assert
+    Assert.NotNull(resultOfT);
+    Assert.False(resultOfT.IsOk);
+    Assert.True(resultOfT.IsFailed);
+    Assert.NotNull(resultOfT.Failure);
+    Assert.Null(resultOfT.Value);
+    Assert.Equal(3, resultOfT.Statements.Facts.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", resultOfT.Statements.Facts[1].Message);
+    Assert.Equal("Fact 3", resultOfT.Statements.Facts[2].Message);
+    Assert.True(resultOfT.HasFact("F3"));
+    Assert.False(resultOfT.HasFact("f3"));
+    Assert.Equal(3, resultOfT.Statements.Warnings.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Warnings[0].Message);
+    Assert.Equal("Warning 2", resultOfT.Statements.Warnings[1].Message);
+    Assert.Equal("Warning 3", resultOfT.Statements.Warnings[2].Message);
+    Assert.Equal(4, resultOfT.Failure.Errors.Count);
+    Assert.Equal("Error 1", resultOfT.Failure.Errors[0].Message);
+    Assert.Equal("Error 2", resultOfT.Failure.Errors[1].Message);
+    Assert.True(resultOfT.IsFailedWith(FailureType.Error));
+    Assert.False(resultOfT.IsFailedWith(FailureType.Unspecified));
+    Assert.False(resultOfT.IsFailedWith("Failure.Error"));
+    Assert.True(resultOfT.IsFailedWith("E2"));
+    Assert.False(resultOfT.IsFailedWith("e2"));
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception)));
+    Assert.True(resultOfT.IsFailedWith<Exception>(true));
+    Assert.True(resultOfT.IsFailedWith<InvalidOperationException>());
+    Assert.True(resultOfT.IsFailedWith<ApplicationException>());
+  }
+
+  [Fact]
+  public async Task OkResultToResultWithValueFuncOnOkAsync()
+  {
+    //Arrange
+    var resultOriginal = Result.Ok().WithFacts([_fact1, _fact2, _fact3]).WithWarnings([_warning1, _warning2, _warning3]);
+    var item1 = 42;
+    var item2 = "Meaning of life.";
+
+    //Act
+    var resultOfT = await resultOriginal.AsResultAsync<ValueClass>(
+      async (ct) =>
+      {
+        await Task.Delay(1, ct);
+        return new ValueClass() { Number = item1, String = item2 };
+      },
+      TestContext.Current.CancellationToken);
+
+    // Assert
+    Assert.True(resultOfT.IsOk);
+    Assert.False(resultOfT.IsFailed);
+    Assert.Null(resultOfT.Failure);
+    Assert.NotNull(resultOfT.Value);
+    Assert.Equal(42, resultOfT.Value.Number);
+    Assert.Equal("Meaning of life.", resultOfT.Value.String);
+    Assert.Equal(3, resultOfT.Statements.Facts.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", resultOfT.Statements.Facts[1].Message);
+    Assert.Equal("Fact 3", resultOfT.Statements.Facts[2].Message);
+    Assert.True(resultOfT.HasFact("F3"));
+    Assert.False(resultOfT.HasFact("f3"));
+    Assert.Equal(3, resultOfT.Statements.Warnings.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Warnings[0].Message);
+    Assert.Equal("Warning 2", resultOfT.Statements.Warnings[1].Message);
+    Assert.Equal("Warning 3", resultOfT.Statements.Warnings[2].Message);
+    Assert.False(resultOfT.IsFailedWith(FailureType.Error));
+    Assert.False(resultOfT.IsFailedWith(FailureType.Unspecified));
+    Assert.False(resultOfT.IsFailedWith("E2"));
+    Assert.False(resultOfT.IsFailedWith("e2"));
+    Assert.False(resultOfT.IsFailedWith<ApplicationException>());
+    Assert.False(resultOfT.IsFailedWith(typeof(InvalidOperationException)));
+    Assert.False(resultOfT.IsFailedWith<InvalidCastException>());
+    Assert.False(resultOfT.IsFailedWith<Exception>());
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception)));
+    Assert.False(resultOfT.IsFailedWith<Exception>(true));
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception), true));
+  }
+
+  [Fact]
+  public async Task FailedResultToResultWithValueFuncOnOkAsync()
+  {
+    //Arrange
+    var resultOriginal = Result
+      .Error(
+        _error1,
+        _error2,
+        new Error(_ex1),
+        new Error(_ex2))
+      .WithFacts([_fact1, _fact2, _fact3])
+      .WithWarnings([_warning1, _warning2, _warning3]);
+    var item1 = 42;
+    var item2 = "Meaning of life.";
+
+    //Act
+    var resultOfT = await resultOriginal.AsResultAsync<ValueClass>(
+      async (ct) =>
+      {
+        await Task.Delay(1, ct);
+        return new ValueClass() { Number = item1, String = item2 };
+      },
+      TestContext.Current.CancellationToken);
+
+    // Assert
+    Assert.NotNull(resultOfT);
+    Assert.False(resultOfT.IsOk);
+    Assert.True(resultOfT.IsFailed);
+    Assert.NotNull(resultOfT.Failure);
+    Assert.Null(resultOfT.Value);
+    Assert.Equal(3, resultOfT.Statements.Facts.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", resultOfT.Statements.Facts[1].Message);
+    Assert.Equal("Fact 3", resultOfT.Statements.Facts[2].Message);
+    Assert.True(resultOfT.HasFact("F3"));
+    Assert.False(resultOfT.HasFact("f3"));
+    Assert.Equal(3, resultOfT.Statements.Warnings.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Warnings[0].Message);
+    Assert.Equal("Warning 2", resultOfT.Statements.Warnings[1].Message);
+    Assert.Equal("Warning 3", resultOfT.Statements.Warnings[2].Message);
+    Assert.Equal(4, resultOfT.Failure.Errors.Count);
+    Assert.Equal("Error 1", resultOfT.Failure.Errors[0].Message);
+    Assert.Equal("Error 2", resultOfT.Failure.Errors[1].Message);
+    Assert.True(resultOfT.IsFailedWith(FailureType.Error));
+    Assert.False(resultOfT.IsFailedWith(FailureType.Unspecified));
+    Assert.False(resultOfT.IsFailedWith("Failure.Error"));
+    Assert.True(resultOfT.IsFailedWith("E2"));
+    Assert.False(resultOfT.IsFailedWith("e2"));
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception)));
+    Assert.True(resultOfT.IsFailedWith<Exception>(true));
+    Assert.True(resultOfT.IsFailedWith<InvalidOperationException>());
+    Assert.True(resultOfT.IsFailedWith<ApplicationException>());
+  }
+
+  [Fact]
+  public async Task OkResultToResultWithValueFuncOnOkAndStateAsync()
+  {
+    //Arrange
+    var resultOriginal = Result.Ok().WithFacts([_fact1, _fact2, _fact3]).WithWarnings([_warning1, _warning2, _warning3]);
+
+    //Act
+    var resultOfT = await resultOriginal.AsResultAsync<(int, string), ValueClass>(
+      async (state, ct) =>
+      {
+        await Task.Delay(1, ct);
+        return new ValueClass() { Number = state.Item1, String = state.Item2 };
+      },
+      (42, "Meaning of life."),
+      TestContext.Current.CancellationToken);
+
+    // Assert
+    Assert.True(resultOfT.IsOk);
+    Assert.False(resultOfT.IsFailed);
+    Assert.Null(resultOfT.Failure);
+    Assert.NotNull(resultOfT.Value);
+    Assert.Equal(42, resultOfT.Value.Number);
+    Assert.Equal("Meaning of life.", resultOfT.Value.String);
+    Assert.Equal(3, resultOfT.Statements.Facts.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", resultOfT.Statements.Facts[1].Message);
+    Assert.Equal("Fact 3", resultOfT.Statements.Facts[2].Message);
+    Assert.True(resultOfT.HasFact("F3"));
+    Assert.False(resultOfT.HasFact("f3"));
+    Assert.Equal(3, resultOfT.Statements.Warnings.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Warnings[0].Message);
+    Assert.Equal("Warning 2", resultOfT.Statements.Warnings[1].Message);
+    Assert.Equal("Warning 3", resultOfT.Statements.Warnings[2].Message);
+    Assert.False(resultOfT.IsFailedWith(FailureType.Error));
+    Assert.False(resultOfT.IsFailedWith(FailureType.Unspecified));
+    Assert.False(resultOfT.IsFailedWith("E2"));
+    Assert.False(resultOfT.IsFailedWith("e2"));
+    Assert.False(resultOfT.IsFailedWith<ApplicationException>());
+    Assert.False(resultOfT.IsFailedWith(typeof(InvalidOperationException)));
+    Assert.False(resultOfT.IsFailedWith<InvalidCastException>());
+    Assert.False(resultOfT.IsFailedWith<Exception>());
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception)));
+    Assert.False(resultOfT.IsFailedWith<Exception>(true));
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception), true));
+  }
+
+  [Fact]
+  public async Task FailedResultToResultWithValueFuncOnOkAndStateAsync()
+  {
+    //Arrange
+    var resultOriginal = Result
+      .Error(
+        _error1,
+        _error2,
+        new Error(_ex1),
+        new Error(_ex2))
+      .WithFacts([_fact1, _fact2, _fact3])
+      .WithWarnings([_warning1, _warning2, _warning3]);
+
+    //Act
+    var resultOfT = await resultOriginal.AsResultAsync<(int, string), ValueClass>(
+      async (state, ct) =>
+      {
+        await Task.Delay(1, ct);
+        return new ValueClass() { Number = state.Item1, String = state.Item2 };
+      },
+      (42, "Meaning of life."),
+      TestContext.Current.CancellationToken);
+
+    // Assert
+    Assert.NotNull(resultOfT);
+    Assert.False(resultOfT.IsOk);
+    Assert.True(resultOfT.IsFailed);
+    Assert.NotNull(resultOfT.Failure);
+    Assert.Null(resultOfT.Value);
+    Assert.Equal(3, resultOfT.Statements.Facts.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", resultOfT.Statements.Facts[1].Message);
+    Assert.Equal("Fact 3", resultOfT.Statements.Facts[2].Message);
+    Assert.True(resultOfT.HasFact("F3"));
+    Assert.False(resultOfT.HasFact("f3"));
+    Assert.Equal(3, resultOfT.Statements.Warnings.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Warnings[0].Message);
+    Assert.Equal("Warning 2", resultOfT.Statements.Warnings[1].Message);
+    Assert.Equal("Warning 3", resultOfT.Statements.Warnings[2].Message);
+    Assert.Equal(4, resultOfT.Failure.Errors.Count);
+    Assert.Equal("Error 1", resultOfT.Failure.Errors[0].Message);
+    Assert.Equal("Error 2", resultOfT.Failure.Errors[1].Message);
+    Assert.True(resultOfT.IsFailedWith(FailureType.Error));
+    Assert.False(resultOfT.IsFailedWith(FailureType.Unspecified));
+    Assert.False(resultOfT.IsFailedWith("Failure.Error"));
+    Assert.True(resultOfT.IsFailedWith("E2"));
+    Assert.False(resultOfT.IsFailedWith("e2"));
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception)));
+    Assert.True(resultOfT.IsFailedWith<Exception>(true));
+    Assert.True(resultOfT.IsFailedWith<InvalidOperationException>());
+    Assert.True(resultOfT.IsFailedWith<ApplicationException>());
+  }
+}
+

--- a/tests/ModResults.Tests/ResultOfTConversionAsTests.cs
+++ b/tests/ModResults.Tests/ResultOfTConversionAsTests.cs
@@ -1,0 +1,523 @@
+﻿namespace ModResults.Tests;
+
+public class ResultOfTConversionAsTests
+{
+  private readonly Fact _fact1, _fact2, _fact3;
+  private readonly Warning _warning1, _warning2, _warning3;
+  private readonly Error _error1, _error2;
+  private readonly InvalidOperationException _ex1;
+  private readonly ApplicationException _ex2;
+
+  public ResultOfTConversionAsTests()
+  {
+    _fact1 = new Fact();
+    _fact2 = new Fact("Fact 2", "F2");
+    _fact3 = new Fact("Fact 3", "F3");
+    _warning1 = new Warning();
+    _warning2 = new Warning("Warning 2", "W2");
+    _warning3 = new Warning("Warning 3", "W3");
+    _error1 = new Error("Error 1");
+    _error2 = new Error("Error 2", code: "E2");
+    _ex1 = new InvalidOperationException("Error 4");
+    _ex2 = new ApplicationException("Error 5", new ArgumentException("Error 5 Inner"));
+  }
+
+  [Fact]
+  public void BasicOkResultOfTToResult()
+  {
+    //Arrange
+    var resultOriginal = Result.Ok(new ValueClass() { Number = 42, String = "Meaning of life." });
+
+    //Act
+    var result = resultOriginal.AsResult();
+
+    // Assert
+    Assert.True(result.IsOk);
+    Assert.False(result.IsFailed);
+    Assert.Null(result.Failure);
+    Assert.False(result.HasStatements());
+    Assert.False(result.HasFacts());
+    Assert.False(result.HasWarnings());
+  }
+
+  [Fact]
+  public void OkResultOfTToResult()
+  {
+    //Arrange
+    var resultOriginal = Result.Ok(new ValueClass() { Number = 42, String = "Meaning of life." }).WithFacts([_fact1, _fact2, _fact3]).WithWarnings([_warning1, _warning2, _warning3]);
+
+    //Act
+    var result = resultOriginal.AsResult();
+
+    // Assert
+    Assert.True(result.IsOk);
+    Assert.False(result.IsFailed);
+    Assert.Null(result.Failure);
+    Assert.Equal(3, result.Statements.Facts.Count);
+    Assert.Equal(string.Empty, result.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", result.Statements.Facts[1].Message);
+    Assert.Equal("Fact 3", result.Statements.Facts[2].Message);
+    Assert.True(result.HasFact("F3"));
+    Assert.False(result.HasFact("f3"));
+    Assert.Equal(3, result.Statements.Warnings.Count);
+    Assert.Equal(string.Empty, result.Statements.Warnings[0].Message);
+    Assert.Equal("Warning 2", result.Statements.Warnings[1].Message);
+    Assert.Equal("Warning 3", result.Statements.Warnings[2].Message);
+    Assert.False(result.IsFailedWith(FailureType.Error));
+    Assert.False(result.IsFailedWith(FailureType.Unspecified));
+    Assert.False(result.IsFailedWith("E2"));
+    Assert.False(result.IsFailedWith("e2"));
+    Assert.False(result.IsFailedWith<ApplicationException>());
+    Assert.False(result.IsFailedWith(typeof(InvalidOperationException)));
+    Assert.False(result.IsFailedWith<InvalidCastException>());
+    Assert.False(result.IsFailedWith<Exception>());
+    Assert.False(result.IsFailedWith(typeof(Exception)));
+    Assert.False(result.IsFailedWith<Exception>(true));
+    Assert.False(result.IsFailedWith(typeof(Exception), true));
+  }
+
+  [Fact]
+  public void BasicFailedResultOfTToResult()
+  {
+    //Arrange
+    var resultOriginal = Result<ValueClass>.Error();
+
+    //Act
+    var resultOfT = resultOriginal.AsResult();
+
+    // Assert
+    Assert.NotNull(resultOfT);
+    Assert.False(resultOfT.IsOk);
+    Assert.True(resultOfT.IsFailed);
+    Assert.NotNull(resultOfT.Failure);
+    Assert.False(resultOfT.HasStatements());
+    Assert.False(resultOfT.HasFacts());
+    Assert.False(resultOfT.HasWarnings());
+    Assert.False(resultOfT.Failure.HasErrors());
+  }
+
+  [Fact]
+  public void FailedResultOfTToResult()
+  {
+    //Arrange
+    var resultOriginal = Result<ValueClass>
+      .Error(
+        _error1,
+        _error2,
+        new Error(_ex1),
+        new Error(_ex2))
+      .WithFacts([_fact1, _fact2, _fact3])
+      .WithWarnings([_warning1, _warning2, _warning3]);
+
+    //Act
+    var resultOfT = resultOriginal.AsResult();
+
+    // Assert
+    Assert.NotNull(resultOfT);
+    Assert.False(resultOfT.IsOk);
+    Assert.True(resultOfT.IsFailed);
+    Assert.NotNull(resultOfT.Failure);
+    Assert.Equal(3, resultOfT.Statements.Facts.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", resultOfT.Statements.Facts[1].Message);
+    Assert.Equal("Fact 3", resultOfT.Statements.Facts[2].Message);
+    Assert.True(resultOfT.HasFact("F3"));
+    Assert.False(resultOfT.HasFact("f3"));
+    Assert.Equal(3, resultOfT.Statements.Warnings.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Warnings[0].Message);
+    Assert.Equal("Warning 2", resultOfT.Statements.Warnings[1].Message);
+    Assert.Equal("Warning 3", resultOfT.Statements.Warnings[2].Message);
+    Assert.Equal(4, resultOfT.Failure.Errors.Count);
+    Assert.Equal("Error 1", resultOfT.Failure.Errors[0].Message);
+    Assert.Equal("Error 2", resultOfT.Failure.Errors[1].Message);
+    Assert.True(resultOfT.IsFailedWith(FailureType.Error));
+    Assert.False(resultOfT.IsFailedWith(FailureType.Unspecified));
+    Assert.False(resultOfT.IsFailedWith("Failure.Error"));
+    Assert.True(resultOfT.IsFailedWith("E2"));
+    Assert.False(resultOfT.IsFailedWith("e2"));
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception)));
+    Assert.True(resultOfT.IsFailedWith<Exception>(true));
+    Assert.True(resultOfT.IsFailedWith<InvalidOperationException>());
+    Assert.True(resultOfT.IsFailedWith<ApplicationException>());
+  }
+
+  [Fact]
+  public void OkResultOfTToResultWithValueOnOk()
+  {
+    //Arrange
+    var result = Result.Ok(new ValueStruct() { Number = 42, String = "Meaning of life." }).WithFacts([_fact1, _fact2, _fact3]).WithWarnings([_warning1, _warning2, _warning3]);
+
+    //Act
+    var resultOfT = result.AsResult<ValueStruct, ValueClass>(
+      (source) => new ValueClass() { Number = source.Number, String = source.String });
+
+    // Assert
+    Assert.True(resultOfT.IsOk);
+    Assert.False(resultOfT.IsFailed);
+    Assert.Null(resultOfT.Failure);
+    Assert.NotNull(resultOfT.Value);
+    Assert.Equal(42, resultOfT.Value.Number);
+    Assert.Equal("Meaning of life.", resultOfT.Value.String);
+    Assert.Equal(3, resultOfT.Statements.Facts.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", resultOfT.Statements.Facts[1].Message);
+    Assert.Equal("Fact 3", resultOfT.Statements.Facts[2].Message);
+    Assert.True(resultOfT.HasFact("F3"));
+    Assert.False(resultOfT.HasFact("f3"));
+    Assert.Equal(3, resultOfT.Statements.Warnings.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Warnings[0].Message);
+    Assert.Equal("Warning 2", resultOfT.Statements.Warnings[1].Message);
+    Assert.Equal("Warning 3", resultOfT.Statements.Warnings[2].Message);
+    Assert.False(resultOfT.IsFailedWith(FailureType.Error));
+    Assert.False(resultOfT.IsFailedWith(FailureType.Unspecified));
+    Assert.False(resultOfT.IsFailedWith("E2"));
+    Assert.False(resultOfT.IsFailedWith("e2"));
+    Assert.False(resultOfT.IsFailedWith<ApplicationException>());
+    Assert.False(resultOfT.IsFailedWith(typeof(InvalidOperationException)));
+    Assert.False(resultOfT.IsFailedWith<InvalidCastException>());
+    Assert.False(resultOfT.IsFailedWith<Exception>());
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception)));
+    Assert.False(resultOfT.IsFailedWith<Exception>(true));
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception), true));
+  }
+
+  [Fact]
+  public void FailedResultOfTToResultWithValueOnOk()
+  {
+    //Arrange
+    var resultOriginal = Result<ValueStruct>
+      .Error(
+        _error1,
+        _error2,
+        new Error(_ex1),
+        new Error(_ex2))
+      .WithFacts([_fact1, _fact2, _fact3])
+      .WithWarnings([_warning1, _warning2, _warning3]);
+
+    //Act
+    var resultOfT = resultOriginal.AsResult<ValueStruct, ValueClass>(
+      (source) => new ValueClass() { Number = source.Number, String = source.String });
+
+    // Assert
+    Assert.NotNull(resultOfT);
+    Assert.False(resultOfT.IsOk);
+    Assert.True(resultOfT.IsFailed);
+    Assert.NotNull(resultOfT.Failure);
+    Assert.Null(resultOfT.Value);
+    Assert.Equal(3, resultOfT.Statements.Facts.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", resultOfT.Statements.Facts[1].Message);
+    Assert.Equal("Fact 3", resultOfT.Statements.Facts[2].Message);
+    Assert.True(resultOfT.HasFact("F3"));
+    Assert.False(resultOfT.HasFact("f3"));
+    Assert.Equal(3, resultOfT.Statements.Warnings.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Warnings[0].Message);
+    Assert.Equal("Warning 2", resultOfT.Statements.Warnings[1].Message);
+    Assert.Equal("Warning 3", resultOfT.Statements.Warnings[2].Message);
+    Assert.Equal(4, resultOfT.Failure.Errors.Count);
+    Assert.Equal("Error 1", resultOfT.Failure.Errors[0].Message);
+    Assert.Equal("Error 2", resultOfT.Failure.Errors[1].Message);
+    Assert.True(resultOfT.IsFailedWith(FailureType.Error));
+    Assert.False(resultOfT.IsFailedWith(FailureType.Unspecified));
+    Assert.False(resultOfT.IsFailedWith("Failure.Error"));
+    Assert.True(resultOfT.IsFailedWith("E2"));
+    Assert.False(resultOfT.IsFailedWith("e2"));
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception)));
+    Assert.True(resultOfT.IsFailedWith<Exception>(true));
+    Assert.True(resultOfT.IsFailedWith<InvalidOperationException>());
+    Assert.True(resultOfT.IsFailedWith<ApplicationException>());
+  }
+
+  [Fact]
+  public void OkResultOfTToResultWithValueFuncOnOk()
+  {
+    //Arrange
+    var resultOriginal = Result
+      .Ok(new ValueStruct() { Number = 42, String = "Meaning of life" })
+      .WithFacts([_fact1, _fact2, _fact3])
+      .WithWarnings([_warning1, _warning2, _warning3]);
+
+    //Act
+    var resultOfT = resultOriginal.AsResult<ValueStruct, string, ValueClass>(
+      (source, state) => new ValueClass() { Number = source.Number, String = source.String + state },
+      ("."));
+
+    // Assert
+    Assert.True(resultOfT.IsOk);
+    Assert.False(resultOfT.IsFailed);
+    Assert.Null(resultOfT.Failure);
+    Assert.NotNull(resultOfT.Value);
+    Assert.Equal(42, resultOfT.Value.Number);
+    Assert.Equal("Meaning of life.", resultOfT.Value.String);
+    Assert.Equal(3, resultOfT.Statements.Facts.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", resultOfT.Statements.Facts[1].Message);
+    Assert.Equal("Fact 3", resultOfT.Statements.Facts[2].Message);
+    Assert.True(resultOfT.HasFact("F3"));
+    Assert.False(resultOfT.HasFact("f3"));
+    Assert.Equal(3, resultOfT.Statements.Warnings.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Warnings[0].Message);
+    Assert.Equal("Warning 2", resultOfT.Statements.Warnings[1].Message);
+    Assert.Equal("Warning 3", resultOfT.Statements.Warnings[2].Message);
+    Assert.False(resultOfT.IsFailedWith(FailureType.Error));
+    Assert.False(resultOfT.IsFailedWith(FailureType.Unspecified));
+    Assert.False(resultOfT.IsFailedWith("E2"));
+    Assert.False(resultOfT.IsFailedWith("e2"));
+    Assert.False(resultOfT.IsFailedWith<ApplicationException>());
+    Assert.False(resultOfT.IsFailedWith(typeof(InvalidOperationException)));
+    Assert.False(resultOfT.IsFailedWith<InvalidCastException>());
+    Assert.False(resultOfT.IsFailedWith<Exception>());
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception)));
+    Assert.False(resultOfT.IsFailedWith<Exception>(true));
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception), true));
+  }
+
+  [Fact]
+  public void FailedResultOfTToResultWithValueFuncOnOk()
+  {
+    //Arrange
+    var resultOriginal = Result<ValueStruct>
+      .Error(
+        _error1,
+        _error2,
+        new Error(_ex1),
+        new Error(_ex2))
+      .WithFacts([_fact1, _fact2, _fact3])
+      .WithWarnings([_warning1, _warning2, _warning3]);
+
+    //Act
+    var resultOfT = resultOriginal.AsResult<ValueStruct, string, ValueClass>(
+      (source, state) => new ValueClass() { Number = source.Number, String = source.String + state },
+      ("."));
+
+    // Assert
+    Assert.NotNull(resultOfT);
+    Assert.False(resultOfT.IsOk);
+    Assert.True(resultOfT.IsFailed);
+    Assert.NotNull(resultOfT.Failure);
+    Assert.Null(resultOfT.Value);
+    Assert.Equal(3, resultOfT.Statements.Facts.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", resultOfT.Statements.Facts[1].Message);
+    Assert.Equal("Fact 3", resultOfT.Statements.Facts[2].Message);
+    Assert.True(resultOfT.HasFact("F3"));
+    Assert.False(resultOfT.HasFact("f3"));
+    Assert.Equal(3, resultOfT.Statements.Warnings.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Warnings[0].Message);
+    Assert.Equal("Warning 2", resultOfT.Statements.Warnings[1].Message);
+    Assert.Equal("Warning 3", resultOfT.Statements.Warnings[2].Message);
+    Assert.Equal(4, resultOfT.Failure.Errors.Count);
+    Assert.Equal("Error 1", resultOfT.Failure.Errors[0].Message);
+    Assert.Equal("Error 2", resultOfT.Failure.Errors[1].Message);
+    Assert.True(resultOfT.IsFailedWith(FailureType.Error));
+    Assert.False(resultOfT.IsFailedWith(FailureType.Unspecified));
+    Assert.False(resultOfT.IsFailedWith("Failure.Error"));
+    Assert.True(resultOfT.IsFailedWith("E2"));
+    Assert.False(resultOfT.IsFailedWith("e2"));
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception)));
+    Assert.True(resultOfT.IsFailedWith<Exception>(true));
+    Assert.True(resultOfT.IsFailedWith<InvalidOperationException>());
+    Assert.True(resultOfT.IsFailedWith<ApplicationException>());
+  }
+
+  [Fact]
+  public async Task OkResultOfTToResultWithValueFuncOnOkAsync()
+  {
+    //Arrange
+    var resultOriginal = Result
+      .Ok(new ValueStruct() { Number = 42, String = "Meaning of life" })
+      .WithFacts([_fact1, _fact2, _fact3])
+      .WithWarnings([_warning1, _warning2, _warning3]);
+    //Act
+    var resultOfT = await resultOriginal.AsResultAsync<ValueStruct, ValueClass>(
+      async (source, ct) =>
+      {
+        await Task.Delay(1, ct);
+        return new ValueClass() { Number = source.Number, String = source.String + "." };
+      },
+      TestContext.Current.CancellationToken);
+
+    // Assert
+    Assert.True(resultOfT.IsOk);
+    Assert.False(resultOfT.IsFailed);
+    Assert.Null(resultOfT.Failure);
+    Assert.NotNull(resultOfT.Value);
+    Assert.Equal(42, resultOfT.Value.Number);
+    Assert.Equal("Meaning of life.", resultOfT.Value.String);
+    Assert.Equal(3, resultOfT.Statements.Facts.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", resultOfT.Statements.Facts[1].Message);
+    Assert.Equal("Fact 3", resultOfT.Statements.Facts[2].Message);
+    Assert.True(resultOfT.HasFact("F3"));
+    Assert.False(resultOfT.HasFact("f3"));
+    Assert.Equal(3, resultOfT.Statements.Warnings.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Warnings[0].Message);
+    Assert.Equal("Warning 2", resultOfT.Statements.Warnings[1].Message);
+    Assert.Equal("Warning 3", resultOfT.Statements.Warnings[2].Message);
+    Assert.False(resultOfT.IsFailedWith(FailureType.Error));
+    Assert.False(resultOfT.IsFailedWith(FailureType.Unspecified));
+    Assert.False(resultOfT.IsFailedWith("E2"));
+    Assert.False(resultOfT.IsFailedWith("e2"));
+    Assert.False(resultOfT.IsFailedWith<ApplicationException>());
+    Assert.False(resultOfT.IsFailedWith(typeof(InvalidOperationException)));
+    Assert.False(resultOfT.IsFailedWith<InvalidCastException>());
+    Assert.False(resultOfT.IsFailedWith<Exception>());
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception)));
+    Assert.False(resultOfT.IsFailedWith<Exception>(true));
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception), true));
+  }
+
+  [Fact]
+  public async Task FailedResultOfTToResultWithValueFuncOnOkAsync()
+  {
+    //Arrange
+    var resultOriginal = Result<ValueStruct>
+      .Error(
+        _error1,
+        _error2,
+        new Error(_ex1),
+        new Error(_ex2))
+      .WithFacts([_fact1, _fact2, _fact3])
+      .WithWarnings([_warning1, _warning2, _warning3]);
+
+    //Act
+    var resultOfT = await resultOriginal.AsResultAsync<ValueStruct, ValueClass>(
+      async (source, ct) =>
+      {
+        await Task.Delay(1, ct);
+        return new ValueClass() { Number = source.Number, String = source.String + "." };
+      },
+      TestContext.Current.CancellationToken);
+
+    // Assert
+    Assert.NotNull(resultOfT);
+    Assert.False(resultOfT.IsOk);
+    Assert.True(resultOfT.IsFailed);
+    Assert.NotNull(resultOfT.Failure);
+    Assert.Null(resultOfT.Value);
+    Assert.Equal(3, resultOfT.Statements.Facts.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", resultOfT.Statements.Facts[1].Message);
+    Assert.Equal("Fact 3", resultOfT.Statements.Facts[2].Message);
+    Assert.True(resultOfT.HasFact("F3"));
+    Assert.False(resultOfT.HasFact("f3"));
+    Assert.Equal(3, resultOfT.Statements.Warnings.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Warnings[0].Message);
+    Assert.Equal("Warning 2", resultOfT.Statements.Warnings[1].Message);
+    Assert.Equal("Warning 3", resultOfT.Statements.Warnings[2].Message);
+    Assert.Equal(4, resultOfT.Failure.Errors.Count);
+    Assert.Equal("Error 1", resultOfT.Failure.Errors[0].Message);
+    Assert.Equal("Error 2", resultOfT.Failure.Errors[1].Message);
+    Assert.True(resultOfT.IsFailedWith(FailureType.Error));
+    Assert.False(resultOfT.IsFailedWith(FailureType.Unspecified));
+    Assert.False(resultOfT.IsFailedWith("Failure.Error"));
+    Assert.True(resultOfT.IsFailedWith("E2"));
+    Assert.False(resultOfT.IsFailedWith("e2"));
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception)));
+    Assert.True(resultOfT.IsFailedWith<Exception>(true));
+    Assert.True(resultOfT.IsFailedWith<InvalidOperationException>());
+    Assert.True(resultOfT.IsFailedWith<ApplicationException>());
+  }
+
+  [Fact]
+  public async Task OkResultOfTToResultWithValueFuncOnOkAndStateAsync()
+  {
+    //Arrange
+    var resultOriginal = Result
+      .Ok(new ValueStruct() { Number = 42, String = "Meaning of life" })
+      .WithFacts([_fact1, _fact2, _fact3])
+      .WithWarnings([_warning1, _warning2, _warning3]);
+    //Act
+    var resultOfT = await resultOriginal.AsResultAsync<ValueStruct, string, ValueClass>(
+      async (source, state, ct) =>
+      {
+        await Task.Delay(1, ct);
+        return new ValueClass() { Number = source.Number, String = source.String + state };
+      },
+      ("."),
+      TestContext.Current.CancellationToken);
+
+    // Assert
+    Assert.True(resultOfT.IsOk);
+    Assert.False(resultOfT.IsFailed);
+    Assert.Null(resultOfT.Failure);
+    Assert.NotNull(resultOfT.Value);
+    Assert.Equal(42, resultOfT.Value.Number);
+    Assert.Equal("Meaning of life.", resultOfT.Value.String);
+    Assert.Equal(3, resultOfT.Statements.Facts.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", resultOfT.Statements.Facts[1].Message);
+    Assert.Equal("Fact 3", resultOfT.Statements.Facts[2].Message);
+    Assert.True(resultOfT.HasFact("F3"));
+    Assert.False(resultOfT.HasFact("f3"));
+    Assert.Equal(3, resultOfT.Statements.Warnings.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Warnings[0].Message);
+    Assert.Equal("Warning 2", resultOfT.Statements.Warnings[1].Message);
+    Assert.Equal("Warning 3", resultOfT.Statements.Warnings[2].Message);
+    Assert.False(resultOfT.IsFailedWith(FailureType.Error));
+    Assert.False(resultOfT.IsFailedWith(FailureType.Unspecified));
+    Assert.False(resultOfT.IsFailedWith("E2"));
+    Assert.False(resultOfT.IsFailedWith("e2"));
+    Assert.False(resultOfT.IsFailedWith<ApplicationException>());
+    Assert.False(resultOfT.IsFailedWith(typeof(InvalidOperationException)));
+    Assert.False(resultOfT.IsFailedWith<InvalidCastException>());
+    Assert.False(resultOfT.IsFailedWith<Exception>());
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception)));
+    Assert.False(resultOfT.IsFailedWith<Exception>(true));
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception), true));
+  }
+
+  [Fact]
+  public async Task FailedResultOfTToResultWithValueFuncOnOkAndStateAsync()
+  {
+    //Arrange
+    var resultOriginal = Result<ValueStruct>
+      .Error(
+        _error1,
+        _error2,
+        new Error(_ex1),
+        new Error(_ex2))
+      .WithFacts([_fact1, _fact2, _fact3])
+      .WithWarnings([_warning1, _warning2, _warning3]);
+
+    //Act
+    var resultOfT = await resultOriginal.AsResultAsync<ValueStruct, string, ValueClass>(
+      async (source, state, ct) =>
+      {
+        await Task.Delay(1, ct);
+        return new ValueClass() { Number = source.Number, String = source.String + state };
+      },
+      ("."),
+      TestContext.Current.CancellationToken);
+
+    // Assert
+    Assert.NotNull(resultOfT);
+    Assert.False(resultOfT.IsOk);
+    Assert.True(resultOfT.IsFailed);
+    Assert.NotNull(resultOfT.Failure);
+    Assert.Null(resultOfT.Value);
+    Assert.Equal(3, resultOfT.Statements.Facts.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Facts[0].Message);
+    Assert.Equal("Fact 2", resultOfT.Statements.Facts[1].Message);
+    Assert.Equal("Fact 3", resultOfT.Statements.Facts[2].Message);
+    Assert.True(resultOfT.HasFact("F3"));
+    Assert.False(resultOfT.HasFact("f3"));
+    Assert.Equal(3, resultOfT.Statements.Warnings.Count);
+    Assert.Equal(string.Empty, resultOfT.Statements.Warnings[0].Message);
+    Assert.Equal("Warning 2", resultOfT.Statements.Warnings[1].Message);
+    Assert.Equal("Warning 3", resultOfT.Statements.Warnings[2].Message);
+    Assert.Equal(4, resultOfT.Failure.Errors.Count);
+    Assert.Equal("Error 1", resultOfT.Failure.Errors[0].Message);
+    Assert.Equal("Error 2", resultOfT.Failure.Errors[1].Message);
+    Assert.True(resultOfT.IsFailedWith(FailureType.Error));
+    Assert.False(resultOfT.IsFailedWith(FailureType.Unspecified));
+    Assert.False(resultOfT.IsFailedWith("Failure.Error"));
+    Assert.True(resultOfT.IsFailedWith("E2"));
+    Assert.False(resultOfT.IsFailedWith("e2"));
+    Assert.False(resultOfT.IsFailedWith(typeof(Exception)));
+    Assert.True(resultOfT.IsFailedWith<Exception>(true));
+    Assert.True(resultOfT.IsFailedWith<InvalidOperationException>());
+    Assert.True(resultOfT.IsFailedWith<ApplicationException>());
+  }
+
+}

--- a/tests/ModResults.Tests/ResultOfTTests.cs
+++ b/tests/ModResults.Tests/ResultOfTTests.cs
@@ -171,7 +171,7 @@ public class ResultOfTTests
       false,
       new Failure(FailureType.Unavailable, errors),
       new Statements(facts, warnings));
-    var resultOfT = Result<ValueStruct>.Fail(result2);
+    var resultOfT = Result<ValueStruct>.Fail(result2, false);
 
     // Act
     var isOk = resultOfT.IsOk;
@@ -265,7 +265,7 @@ public class ResultOfTTests
       new Statements(facts, warnings));
 
     // Act
-    var resultOfT = Result<ValueRecord>.Fail(result2);
+    var resultOfT = Result<ValueRecord>.Fail(result2, false);
 
     // Assert
     Assert.False(resultOfT.IsOk);


### PR DESCRIPTION
- Add static factory method `FailureResult.From()` to convert any `BaseResult<Failure>` type (e.g. `Result`, `Result<TValue>`)  into FailureResult.
- Introduce `AsResult()` conversion methods for `Result` and `Result<TValue>`. These methods wrap Failure/Statements properties of source result instead of creating new property objects and copying information, which `ToResult()` do.
- Add wrapSourceProperties param to static Fail methods of `Result` and `Result<TValue>`, for control over wrapping vs copying. Wrapping is now default behavior.
- Add tests for new features and behaviors.
- Update documentation.